### PR TITLE
feat: add GitHub Pages deployment for example games

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,56 @@
+name: Deploy Examples to GitHub Pages
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build core package
+        run: npm run build --workspace=core
+
+      - name: Build examples
+        run: npm run build --workspace=examples
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./examples/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/examples/games/asteroids-browser.ts
+++ b/examples/games/asteroids-browser.ts
@@ -1,0 +1,217 @@
+/**
+ * Browser wrapper for Asteroids game
+ * Adds canvas rendering and keyboard input to the core game logic
+ */
+
+import {
+    Asteroid,
+    engine,
+    gameLoop,
+    InputState,
+    initGame,
+    Player,
+    Position,
+    Renderable,
+    Rotation,
+} from './asteroids';
+
+// Constants
+const SCREEN_WIDTH = 800;
+const SCREEN_HEIGHT = 600;
+
+// Canvas setup
+const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+const ctx = canvas.getContext('2d')!;
+
+// UI elements
+const scoreEl = document.getElementById('score')!;
+const livesEl = document.getElementById('lives')!;
+const gameOverEl = document.getElementById('game-over')!;
+const finalScoreEl = document.getElementById('final-score')!;
+const restartBtn = document.getElementById('restart')!;
+
+// Game state
+let isGameOver = false;
+
+// Initialize the game
+initGame();
+
+// Get player entity for UI updates
+function getPlayer() {
+    const entities = engine.getEntitiesWithComponent(Player);
+    return entities.length > 0 ? entities[0] : null;
+}
+
+// Keyboard input handling
+const keys: { [key: string]: boolean } = {};
+
+window.addEventListener('keydown', (e) => {
+    keys[e.key.toLowerCase()] = true;
+
+    const player = getPlayer();
+    if (player) {
+        const input = player.getComponent(InputState);
+        if (input) {
+            input.left = keys['arrowleft'] || keys['a'];
+            input.right = keys['arrowright'] || keys['d'];
+            input.thrust = keys['arrowup'] || keys['w'];
+            input.shoot = keys[' '] || keys['space'];
+        }
+    }
+});
+
+window.addEventListener('keyup', (e) => {
+    keys[e.key.toLowerCase()] = false;
+
+    const player = getPlayer();
+    if (player) {
+        const input = player.getComponent(InputState);
+        if (input) {
+            input.left = keys['arrowleft'] || keys['a'];
+            input.right = keys['arrowright'] || keys['d'];
+            input.thrust = keys['arrowup'] || keys['w'];
+            input.shoot = keys[' '] || keys['space'];
+        }
+    }
+});
+
+// Rendering
+function render() {
+    // Clear canvas
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    // Render all entities with Position and Renderable components
+    const entities = engine.getEntitiesWithComponent(Position);
+
+    for (const entity of entities) {
+        const position = entity.getComponent(Position);
+        const renderable = entity.getComponent(Renderable);
+
+        if (!position || !renderable) continue;
+
+        const rotation = entity.getComponent(Rotation);
+        const angle = rotation ? rotation.angle : 0;
+
+        ctx.save();
+        ctx.translate(position.x, position.y);
+        ctx.rotate(angle);
+
+        // Draw based on sprite type
+        ctx.strokeStyle = renderable.color;
+        ctx.fillStyle = renderable.color;
+        ctx.lineWidth = 2;
+
+        switch (renderable.sprite) {
+            case 'player': {
+                // Draw ship as triangle
+                const size = renderable.size * 15;
+                ctx.beginPath();
+                ctx.moveTo(size, 0);
+                ctx.lineTo(-size, size);
+                ctx.lineTo(-size * 0.5, 0);
+                ctx.lineTo(-size, -size);
+                ctx.closePath();
+                ctx.stroke();
+
+                // Draw thrust flame if thrusting
+                if (entity.hasComponent(InputState)) {
+                    const input = entity.getComponent(InputState)!;
+                    if (input.thrust) {
+                        ctx.fillStyle = '#FFA500';
+                        ctx.beginPath();
+                        ctx.moveTo(-size, size * 0.5);
+                        ctx.lineTo(-size * 1.5, 0);
+                        ctx.lineTo(-size, -size * 0.5);
+                        ctx.closePath();
+                        ctx.fill();
+                    }
+                }
+                break;
+            }
+            case 'asteroid': {
+                // Draw asteroid as irregular polygon
+                const asteroid = entity.getComponent(Asteroid);
+                const size = asteroid ? asteroid.size * 15 : 30;
+                const sides = 8;
+                ctx.beginPath();
+                for (let i = 0; i <= sides; i++) {
+                    const angle = (Math.PI * 2 * i) / sides;
+                    const radius = size * (0.8 + Math.random() * 0.4);
+                    const x = Math.cos(angle) * radius;
+                    const y = Math.sin(angle) * radius;
+                    if (i === 0) ctx.moveTo(x, y);
+                    else ctx.lineTo(x, y);
+                }
+                ctx.closePath();
+                ctx.stroke();
+                break;
+            }
+            case 'bullet': {
+                // Draw bullet as small circle
+                const size = renderable.size * 3;
+                ctx.beginPath();
+                ctx.arc(0, 0, size, 0, Math.PI * 2);
+                ctx.fill();
+                break;
+            }
+        }
+
+        ctx.restore();
+    }
+}
+
+// Update UI
+function updateUI() {
+    const player = getPlayer();
+
+    if (player) {
+        const playerComp = player.getComponent(Player);
+        if (playerComp) {
+            scoreEl.textContent = playerComp.score.toString();
+            livesEl.textContent = playerComp.lives.toString();
+
+            // Check for game over
+            if (playerComp.lives <= 0 && !isGameOver) {
+                isGameOver = true;
+                showGameOver(playerComp.score);
+            }
+        }
+    }
+}
+
+// Show game over screen
+function showGameOver(score: number) {
+    finalScoreEl.textContent = score.toString();
+    gameOverEl.style.display = 'block';
+}
+
+// Restart game
+restartBtn.addEventListener('click', () => {
+    // Clear all entities
+    const allEntities = engine.getAllEntities();
+    for (const entity of allEntities) {
+        entity.queueFree();
+    }
+
+    // Re-initialize
+    initGame();
+    isGameOver = false;
+    gameOverEl.style.display = 'none';
+});
+
+// Main game loop
+function browserGameLoop() {
+    if (!isGameOver) {
+        gameLoop();
+        render();
+        updateUI();
+    }
+    requestAnimationFrame(browserGameLoop);
+}
+
+// Start the game
+browserGameLoop();
+
+console.log('🎮 Asteroids game started!');
+console.log('Controls: Arrow Keys / WASD to move, Space to shoot');

--- a/examples/games/asteroids.html
+++ b/examples/games/asteroids.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Asteroids - OrionECS Example</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: #000;
+            color: #fff;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            overflow: hidden;
+        }
+
+        #game-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        canvas {
+            border: 2px solid #333;
+            box-shadow: 0 0 20px rgba(100, 150, 255, 0.3);
+        }
+
+        #ui {
+            display: flex;
+            gap: 2rem;
+            font-size: 1.2rem;
+            font-weight: bold;
+            color: #fff;
+        }
+
+        #ui > div {
+            padding: 0.5rem 1rem;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 6px;
+        }
+
+        #controls {
+            margin-top: 1rem;
+            text-align: center;
+            color: #aaa;
+            font-size: 0.9rem;
+        }
+
+        #controls p {
+            margin: 0.5rem 0;
+        }
+
+        #game-over {
+            display: none;
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(0, 0, 0, 0.9);
+            padding: 2rem;
+            border-radius: 12px;
+            border: 2px solid #667eea;
+            text-align: center;
+        }
+
+        #game-over h2 {
+            color: #667eea;
+            margin-bottom: 1rem;
+        }
+
+        #game-over button {
+            margin-top: 1rem;
+            padding: 0.75rem 1.5rem;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        #game-over button:hover {
+            opacity: 0.9;
+        }
+
+        .back-link {
+            position: fixed;
+            top: 1rem;
+            left: 1rem;
+            color: #667eea;
+            text-decoration: none;
+            padding: 0.5rem 1rem;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 6px;
+            transition: background 0.3s ease;
+        }
+
+        .back-link:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+    </style>
+</head>
+<body>
+    <a href="../index.html" class="back-link">← Back to Examples</a>
+
+    <div id="game-container">
+        <div id="ui">
+            <div>Score: <span id="score">0</span></div>
+            <div>Lives: <span id="lives">3</span></div>
+        </div>
+        <canvas id="game-canvas" width="800" height="600"></canvas>
+        <div id="controls">
+            <p><strong>Controls:</strong></p>
+            <p>Arrow Keys / WASD: Move and Rotate</p>
+            <p>Space: Shoot</p>
+        </div>
+    </div>
+
+    <div id="game-over">
+        <h2>Game Over!</h2>
+        <p>Final Score: <span id="final-score">0</span></p>
+        <button id="restart">Play Again</button>
+    </div>
+
+    <script type="module" src="./asteroids-browser.ts"></script>
+</body>
+</html>

--- a/examples/games/platformer-browser.ts
+++ b/examples/games/platformer-browser.ts
@@ -1,0 +1,268 @@
+/**
+ * Browser wrapper for Platformer game
+ * Adds canvas rendering and keyboard input to the core game logic
+ */
+
+import {
+    BoxCollider,
+    Camera,
+    Collectible,
+    EnemyAI,
+    engine,
+    gameLoop,
+    Input,
+    initGame,
+    Platform,
+    PlayerController,
+    PlayerStats,
+    Position,
+    Sprite,
+} from './platformer';
+
+// Constants
+const SCREEN_WIDTH = 800;
+const SCREEN_HEIGHT = 600;
+
+// Canvas setup
+const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+const ctx = canvas.getContext('2d')!;
+
+// UI elements
+const coinsEl = document.getElementById('coins')!;
+const totalCoinsEl = document.getElementById('total-coins')!;
+const timeEl = document.getElementById('time')!;
+
+// Game state
+let gameTime = 0;
+
+// Initialize the game
+initGame();
+
+// Count total coins
+const totalCoins = engine.getEntitiesWithComponent(Collectible).length;
+totalCoinsEl.textContent = totalCoins.toString();
+
+// Get player entity
+function getPlayer() {
+    const entities = engine.getEntitiesWithComponent(PlayerController);
+    return entities.length > 0 ? entities[0] : null;
+}
+
+// Get camera
+function getCamera() {
+    const entities = engine.getEntitiesWithComponent(Camera);
+    return entities.length > 0 ? entities[0].getComponent(Camera) : null;
+}
+
+// Keyboard input handling
+const keys: { [key: string]: boolean } = {};
+let previousJumpState = false;
+
+window.addEventListener('keydown', (e) => {
+    keys[e.key.toLowerCase()] = true;
+    updatePlayerInput();
+});
+
+window.addEventListener('keyup', (e) => {
+    keys[e.key.toLowerCase()] = false;
+    updatePlayerInput();
+});
+
+function updatePlayerInput() {
+    const player = getPlayer();
+    if (player) {
+        const input = player.getComponent(Input);
+        if (input) {
+            input.left = keys['arrowleft'] || keys['a'];
+            input.right = keys['arrowright'] || keys['d'];
+            const jumpDown = keys[' '] || keys['space'] || keys['arrowup'] || keys['w'];
+            input.jumpPressed = jumpDown && !previousJumpState;
+            input.jump = jumpDown;
+            input.down = keys['arrowdown'] || keys['s'];
+            previousJumpState = jumpDown;
+        }
+    }
+}
+
+// Rendering
+function render() {
+    const camera = getCamera();
+    const cameraX = camera ? camera.x : 0;
+    const cameraY = camera ? camera.y : 0;
+
+    // Clear canvas with sky gradient
+    const gradient = ctx.createLinearGradient(0, 0, 0, SCREEN_HEIGHT);
+    gradient.addColorStop(0, '#87CEEB');
+    gradient.addColorStop(1, '#E0F6FF');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    ctx.save();
+    ctx.translate(-cameraX + SCREEN_WIDTH / 2, -cameraY + SCREEN_HEIGHT / 2);
+
+    // Render platforms
+    const platforms = engine.getEntitiesWithComponent(Platform);
+    for (const entity of platforms) {
+        const position = entity.getComponent(Position);
+        const collider = entity.getComponent(BoxCollider);
+        const platform = entity.getComponent(Platform);
+
+        if (!position || !collider) continue;
+
+        ctx.fillStyle = platform?.isOneWay ? '#8B7355' : '#654321';
+        ctx.strokeStyle = '#000';
+        ctx.lineWidth = 2;
+
+        const x = position.x + collider.offsetX - collider.width / 2;
+        const y = position.y + collider.offsetY - collider.height / 2;
+
+        ctx.fillRect(x, y, collider.width, collider.height);
+        ctx.strokeRect(x, y, collider.width, collider.height);
+
+        // Add texture for one-way platforms
+        if (platform?.isOneWay) {
+            ctx.fillStyle = '#A0826D';
+            for (let i = 0; i < collider.width; i += 8) {
+                ctx.fillRect(x + i, y, 4, collider.height);
+            }
+        }
+    }
+
+    // Render collectibles
+    const collectibles = engine.getEntitiesWithComponent(Collectible);
+    for (const entity of collectibles) {
+        const position = entity.getComponent(Position);
+        if (!position) continue;
+
+        // Draw coin
+        ctx.fillStyle = '#FFD700';
+        ctx.strokeStyle = '#FFA500';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(position.x, position.y, 8, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        // Add shine effect
+        ctx.fillStyle = '#FFEB3B';
+        ctx.beginPath();
+        ctx.arc(position.x - 3, position.y - 3, 3, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    // Render enemies
+    const enemies = engine.getEntitiesWithComponent(EnemyAI);
+    for (const entity of enemies) {
+        const position = entity.getComponent(Position);
+        const collider = entity.getComponent(BoxCollider);
+
+        if (!position || !collider) continue;
+
+        // Draw enemy as red rectangle with angry face
+        ctx.fillStyle = '#FF4444';
+        ctx.strokeStyle = '#CC0000';
+        ctx.lineWidth = 2;
+
+        const x = position.x + collider.offsetX - collider.width / 2;
+        const y = position.y + collider.offsetY - collider.height / 2;
+
+        ctx.fillRect(x, y, collider.width, collider.height);
+        ctx.strokeRect(x, y, collider.width, collider.height);
+
+        // Draw eyes
+        ctx.fillStyle = '#FFF';
+        ctx.fillRect(position.x - 8, position.y - 8, 6, 6);
+        ctx.fillRect(position.x + 2, position.y - 8, 6, 6);
+
+        // Draw pupils
+        ctx.fillStyle = '#000';
+        ctx.fillRect(position.x - 6, position.y - 6, 3, 3);
+        ctx.fillRect(position.x + 4, position.y - 6, 3, 3);
+    }
+
+    // Render player
+    const player = getPlayer();
+    if (player) {
+        const position = player.getComponent(Position);
+        const collider = player.getComponent(BoxCollider);
+        const sprite = player.getComponent(Sprite);
+
+        if (position && collider) {
+            ctx.fillStyle = '#4444FF';
+            ctx.strokeStyle = '#0000CC';
+            ctx.lineWidth = 2;
+
+            const x = position.x + collider.offsetX - collider.width / 2;
+            const y = position.y + collider.offsetY - collider.height / 2;
+
+            // Flip if needed
+            if (sprite?.flipX) {
+                ctx.save();
+                ctx.translate(position.x, 0);
+                ctx.scale(-1, 1);
+                ctx.translate(-position.x, 0);
+            }
+
+            ctx.fillRect(x, y, collider.width, collider.height);
+            ctx.strokeRect(x, y, collider.width, collider.height);
+
+            // Draw simple face
+            ctx.fillStyle = '#FFF';
+            ctx.fillRect(position.x - 8, position.y - 8, 5, 5);
+            ctx.fillRect(position.x + 3, position.y - 8, 5, 5);
+
+            // Draw pupils
+            ctx.fillStyle = '#000';
+            ctx.fillRect(position.x - 6, position.y - 6, 2, 2);
+            ctx.fillRect(position.x + 5, position.y - 6, 2, 2);
+
+            // Draw smile
+            ctx.strokeStyle = '#000';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(position.x, position.y, 8, 0.2 * Math.PI, 0.8 * Math.PI);
+            ctx.stroke();
+
+            if (sprite?.flipX) {
+                ctx.restore();
+            }
+        }
+    }
+
+    ctx.restore();
+}
+
+// Update UI
+function updateUI(deltaTime: number) {
+    gameTime += deltaTime;
+    timeEl.textContent = gameTime.toFixed(1);
+
+    const player = getPlayer();
+    if (player) {
+        const stats = player.getComponent(PlayerStats);
+        if (stats) {
+            coinsEl.textContent = stats.coinsCollected.toString();
+        }
+    }
+}
+
+// Main game loop
+let lastTime = performance.now();
+
+function browserGameLoop() {
+    const currentTime = performance.now();
+    const deltaTime = (currentTime - lastTime) / 1000; // Convert to seconds
+    lastTime = currentTime;
+
+    gameLoop();
+    render();
+    updateUI(deltaTime);
+
+    requestAnimationFrame(browserGameLoop);
+}
+
+// Start the game
+browserGameLoop();
+
+console.log('🏃 Platformer game started!');
+console.log('Controls: Arrow Keys / A & D to move, Space / W to jump');

--- a/examples/games/platformer.html
+++ b/examples/games/platformer.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Platformer - OrionECS Example</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(180deg, #87CEEB 0%, #98D8E8 100%);
+            color: #333;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            overflow: hidden;
+        }
+
+        #game-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        canvas {
+            border: 3px solid #654321;
+            box-shadow: 0 0 30px rgba(0,0,0,0.3);
+            background: #87CEEB;
+        }
+
+        #ui {
+            display: flex;
+            gap: 2rem;
+            font-size: 1.2rem;
+            font-weight: bold;
+            color: #333;
+        }
+
+        #ui > div {
+            padding: 0.5rem 1rem;
+            background: rgba(255, 255, 255, 0.8);
+            border-radius: 6px;
+            border: 2px solid #654321;
+        }
+
+        #controls {
+            margin-top: 1rem;
+            text-align: center;
+            color: #333;
+            font-size: 0.9rem;
+            background: rgba(255, 255, 255, 0.6);
+            padding: 1rem;
+            border-radius: 6px;
+        }
+
+        #controls p {
+            margin: 0.5rem 0;
+        }
+
+        .back-link {
+            position: fixed;
+            top: 1rem;
+            left: 1rem;
+            color: #667eea;
+            text-decoration: none;
+            padding: 0.5rem 1rem;
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 6px;
+            border: 2px solid #667eea;
+            font-weight: 600;
+            transition: background 0.3s ease;
+        }
+
+        .back-link:hover {
+            background: rgba(255, 255, 255, 1);
+        }
+    </style>
+</head>
+<body>
+    <a href="../index.html" class="back-link">← Back to Examples</a>
+
+    <div id="game-container">
+        <div id="ui">
+            <div>💰 Coins: <span id="coins">0</span>/<span id="total-coins">0</span></div>
+            <div>⏱️ Time: <span id="time">0.0</span>s</div>
+        </div>
+        <canvas id="game-canvas" width="800" height="600"></canvas>
+        <div id="controls">
+            <p><strong>Controls:</strong></p>
+            <p>Arrow Keys / A & D: Move Left/Right</p>
+            <p>Space / W / Up Arrow: Jump</p>
+            <p>Collect all coins and avoid enemies!</p>
+        </div>
+    </div>
+
+    <script type="module" src="./platformer-browser.ts"></script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OrionECS Examples</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        header {
+            text-align: center;
+            color: white;
+            margin-bottom: 3rem;
+        }
+
+        h1 {
+            font-size: 3rem;
+            margin-bottom: 0.5rem;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+        }
+
+        .subtitle {
+            font-size: 1.2rem;
+            opacity: 0.9;
+        }
+
+        .examples-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-bottom: 3rem;
+        }
+
+        .example-card {
+            background: white;
+            border-radius: 12px;
+            padding: 2rem;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            text-decoration: none;
+            color: inherit;
+            display: block;
+        }
+
+        .example-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 15px 40px rgba(0,0,0,0.4);
+        }
+
+        .example-card h2 {
+            color: #667eea;
+            margin-bottom: 1rem;
+            font-size: 1.8rem;
+        }
+
+        .example-card p {
+            color: #666;
+            line-height: 1.6;
+            margin-bottom: 1rem;
+        }
+
+        .example-card .features {
+            list-style: none;
+            margin-top: 1rem;
+        }
+
+        .example-card .features li {
+            padding: 0.3rem 0;
+            color: #555;
+            font-size: 0.9rem;
+        }
+
+        .example-card .features li:before {
+            content: "→ ";
+            color: #667eea;
+            font-weight: bold;
+        }
+
+        .example-card .btn {
+            display: inline-block;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 0.75rem 1.5rem;
+            border-radius: 6px;
+            margin-top: 1rem;
+            font-weight: 600;
+            transition: opacity 0.3s ease;
+        }
+
+        .example-card .btn:hover {
+            opacity: 0.9;
+        }
+
+        footer {
+            text-align: center;
+            color: white;
+            padding: 2rem;
+            opacity: 0.9;
+        }
+
+        footer a {
+            color: white;
+            text-decoration: underline;
+        }
+
+        .badge {
+            display: inline-block;
+            background: #667eea;
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.5rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🚀 OrionECS Examples</h1>
+            <p class="subtitle">Interactive demonstrations of the OrionECS framework</p>
+        </header>
+
+        <div class="examples-grid">
+            <a href="./games/asteroids.html" class="example-card">
+                <h2>🎮 Asteroids <span class="badge">GAME</span></h2>
+                <p>Classic arcade game demonstrating physics, collision detection, and object pooling.</p>
+                <ul class="features">
+                    <li>Component pooling for bullets and particles</li>
+                    <li>Prefab system for entity templates</li>
+                    <li>Fixed-rate physics at 60 FPS</li>
+                    <li>Inter-system messaging</li>
+                    <li>Circular collision detection</li>
+                </ul>
+                <span class="btn">Play Game →</span>
+            </a>
+
+            <a href="./games/platformer.html" class="example-card">
+                <h2>🏃 Platformer <span class="badge">GAME</span></h2>
+                <p>Advanced physics-based platformer with enemy AI, collectibles, and state machines.</p>
+                <ul class="features">
+                    <li>Gravity and physics systems</li>
+                    <li>AABB collision with platforms</li>
+                    <li>State machines for character behavior</li>
+                    <li>Camera following system</li>
+                    <li>Enemy AI with patrol behavior</li>
+                </ul>
+                <span class="btn">Play Game →</span>
+            </a>
+
+            <a href="./integrations/pixi.html" class="example-card">
+                <h2>🎨 Pixi.js Integration <span class="badge">INTEGRATION</span></h2>
+                <p>Integration with Pixi.js rendering engine for 2D graphics and sprites.</p>
+                <ul class="features">
+                    <li>Component lifecycle hooks</li>
+                    <li>Sprite and graphics object management</li>
+                    <li>Display object synchronization</li>
+                    <li>Z-indexing and render layers</li>
+                    <li>Texture loading and caching</li>
+                </ul>
+                <span class="btn">View Demo →</span>
+            </a>
+        </div>
+
+        <footer>
+            <p>
+                Built with <strong>OrionECS</strong> - A comprehensive Entity Component System framework
+                <br>
+                <a href="https://github.com/tyevco/OrionECS" target="_blank">View on GitHub</a>
+            </p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/examples/integrations/pixi-browser.ts
+++ b/examples/integrations/pixi-browser.ts
@@ -1,0 +1,95 @@
+/**
+ * Browser wrapper for Pixi.js integration example
+ * Initializes Pixi.js and demonstrates ECS-Pixi integration
+ */
+
+import { Application } from 'pixi.js';
+import {
+    createExampleScene,
+    engine,
+    gameLoop,
+    init,
+    PixiAppManager,
+    pixiManager,
+} from './pixi-example';
+
+// UI elements
+const entityCountEl = document.getElementById('entity-count')!;
+const fpsEl = document.getElementById('fps')!;
+const canvasContainer = document.getElementById('pixi-canvas')!;
+
+// FPS tracking
+let frameCount = 0;
+let lastFpsTime = performance.now();
+let currentFps = 60;
+
+// Initialize Pixi Application
+const app = new Application();
+
+async function initPixi() {
+    await app.init({
+        width: 800,
+        height: 600,
+        backgroundColor: 0x1e3c72,
+    });
+
+    // Append canvas to container
+    canvasContainer.appendChild(app.canvas);
+
+    // Set up the Pixi manager with the application
+    if (pixiManager instanceof PixiAppManager) {
+        pixiManager.app = app;
+
+        // Load textures (if any)
+        // For this example, we'll use procedural graphics
+        // In a real app, you would load sprite textures here:
+        // await Assets.load(['player.png', 'enemy.png']);
+        // pixiManager.textures['player'] = Assets.get('player');
+
+        console.log('✓ Pixi.js initialized');
+    }
+
+    // Initialize the ECS systems
+    await init();
+
+    // Create example scene
+    createExampleScene();
+
+    console.log('✓ Example scene created');
+}
+
+// Update UI stats
+function updateStats() {
+    // Update entity count
+    const entityCount = engine.getAllEntities().length;
+    entityCountEl.textContent = entityCount.toString();
+
+    // Update FPS
+    frameCount++;
+    const currentTime = performance.now();
+    const deltaTime = currentTime - lastFpsTime;
+
+    if (deltaTime >= 1000) {
+        currentFps = Math.round((frameCount * 1000) / deltaTime);
+        fpsEl.textContent = currentFps.toString();
+        frameCount = 0;
+        lastFpsTime = currentTime;
+    }
+}
+
+// Main game loop
+function browserGameLoop() {
+    gameLoop();
+    updateStats();
+    requestAnimationFrame(browserGameLoop);
+}
+
+// Start the application
+initPixi()
+    .then(() => {
+        console.log('🎨 Pixi.js integration example started!');
+        browserGameLoop();
+    })
+    .catch((error) => {
+        console.error('Failed to initialize Pixi.js:', error);
+    });

--- a/examples/integrations/pixi.html
+++ b/examples/integrations/pixi.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pixi.js Integration - OrionECS Example</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            color: #fff;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            overflow: hidden;
+        }
+
+        #game-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        #pixi-canvas {
+            border: 2px solid #667eea;
+            box-shadow: 0 0 30px rgba(102, 126, 234, 0.5);
+        }
+
+        #info {
+            text-align: center;
+            background: rgba(255, 255, 255, 0.1);
+            padding: 1rem;
+            border-radius: 6px;
+            max-width: 600px;
+        }
+
+        #info h2 {
+            color: #667eea;
+            margin-bottom: 0.5rem;
+        }
+
+        #info p {
+            margin: 0.5rem 0;
+            line-height: 1.6;
+        }
+
+        .feature-list {
+            list-style: none;
+            margin-top: 1rem;
+            text-align: left;
+        }
+
+        .feature-list li {
+            padding: 0.3rem 0;
+            padding-left: 1.5rem;
+            position: relative;
+        }
+
+        .feature-list li:before {
+            content: "✓";
+            position: absolute;
+            left: 0;
+            color: #667eea;
+            font-weight: bold;
+        }
+
+        .back-link {
+            position: fixed;
+            top: 1rem;
+            left: 1rem;
+            color: #667eea;
+            text-decoration: none;
+            padding: 0.5rem 1rem;
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 6px;
+            border: 2px solid #667eea;
+            font-weight: 600;
+            transition: background 0.3s ease;
+        }
+
+        .back-link:hover {
+            background: rgba(255, 255, 255, 1);
+        }
+
+        #stats {
+            display: flex;
+            gap: 2rem;
+            font-size: 1rem;
+            margin-top: 1rem;
+        }
+
+        #stats > div {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+        }
+    </style>
+</head>
+<body>
+    <a href="../index.html" class="back-link">← Back to Examples</a>
+
+    <div id="game-container">
+        <div id="info">
+            <h2>🎨 Pixi.js + OrionECS Integration</h2>
+            <p>This example demonstrates how to integrate OrionECS with Pixi.js for high-performance 2D rendering.</p>
+            <ul class="feature-list">
+                <li>Automatic sprite lifecycle management</li>
+                <li>Component-based rendering synchronization</li>
+                <li>Display object pooling and cleanup</li>
+                <li>Z-indexing and render layers</li>
+            </ul>
+        </div>
+
+        <div id="stats">
+            <div>Entities: <span id="entity-count">0</span></div>
+            <div>FPS: <span id="fps">60</span></div>
+        </div>
+
+        <div id="pixi-canvas"></div>
+    </div>
+
+    <script type="module" src="./pixi-browser.ts"></script>
+</body>
+</html>

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@orionecs/examples",
+  "version": "2.0.0",
+  "private": true,
+  "description": "OrionECS example games and integrations",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "orion-ecs": "*",
+    "pixi.js": "^8.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^6.0.1"
+  }
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "games/**/*.ts", "integrations/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    base: '/OrionECS/',
+    build: {
+        outDir: 'dist',
+        rollupOptions: {
+            input: {
+                main: resolve(__dirname, 'index.html'),
+                asteroids: resolve(__dirname, 'games/asteroids.html'),
+                platformer: resolve(__dirname, 'games/platformer.html'),
+                pixi: resolve(__dirname, 'integrations/pixi.html'),
+            },
+        },
+    },
+    resolve: {
+        alias: {
+            '@orionecs/core': resolve(__dirname, '../core/src/index.ts'),
+        },
+    },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "workspaces": [
         "core",
         "utils",
+        "examples",
         "plugins/canvas2d-renderer",
         "plugins/input-manager",
         "plugins/interaction-system",
@@ -66,6 +67,18 @@
         "ts-jest": "^29.4.5",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3"
+      }
+    },
+    "examples": {
+      "name": "@orionecs/examples",
+      "version": "2.0.0",
+      "dependencies": {
+        "orion-ecs": "*",
+        "pixi.js": "^8.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vite": "^6.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4308,6 +4321,10 @@
       "resolved": "utils",
       "link": true
     },
+    "node_modules/@orionecs/examples": {
+      "resolved": "examples",
+      "link": true
+    },
     "node_modules/@oxlint/darwin-arm64": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.29.0.tgz",
@@ -4419,6 +4436,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4852,6 +4875,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5216,6 +5251,21 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -6224,6 +6274,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -6381,7 +6437,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -6657,6 +6712,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
       }
     },
     "node_modules/git-raw-commits": {
@@ -6997,6 +7061,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8900,6 +8970,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9530,6 +9606,25 @@
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -9812,6 +9907,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -9923,6 +10024,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pixi.js": {
+      "version": "8.14.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.14.3.tgz",
+      "integrity": "sha512-6xGYARV8D9E/fO1c2NmYn+k2dQ5oZldVm5tNlLQJ8obTlOQXdL5QpMc217qTpRyHVDFaw5eoFCLF1gr6p5ZcjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/css-font-loading-module": "^0.0.12",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.40",
+        "@xmldom/xmldom": "^0.8.10",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -10020,6 +10144,35 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
@@ -10460,6 +10613,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -10892,6 +11055,15 @@
       "license": "MIT",
       "dependencies": {
         "readable-stream": "3"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.5.tgz",
+      "integrity": "sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tinyexec": {
@@ -11438,6 +11610,578 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "workspaces": [
     "core",
     "utils",
+    "examples",
     "plugins/canvas2d-renderer",
     "plugins/input-manager",
     "plugins/interaction-system",

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,16 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
-      "inputs": ["src/**", "tsconfig.json", "tsup.config.ts", "package.json"]
+      "inputs": [
+        "src/**",
+        "games/**",
+        "integrations/**",
+        "*.html",
+        "tsconfig.json",
+        "tsup.config.ts",
+        "vite.config.ts",
+        "package.json"
+      ]
     },
     "test": {
       "dependsOn": ["build"],
@@ -56,11 +65,6 @@
       "outputs": []
     }
   },
-  "globalDependencies": [
-    "package-lock.json",
-    "tsconfig.json"
-  ],
-  "globalEnv": [
-    "NODE_ENV"
-  ]
+  "globalDependencies": ["package-lock.json", "tsconfig.json"],
+  "globalEnv": ["NODE_ENV"]
 }


### PR DESCRIPTION
This commit sets up the infrastructure to build and serve the OrionECS example games on GitHub Pages.

Changes:
- Add examples workspace with Vite-based build configuration
- Create browser wrappers for all three examples (Asteroids, Platformer, Pixi.js)
- Add HTML entry files with canvas rendering and keyboard input
- Create attractive landing page for navigating between examples
- Set up GitHub Actions workflow for automated deployment
- Update monorepo configuration to include examples workspace

Examples now include:
- Asteroids: Classic arcade game with physics and collision detection
- Platformer: Physics-based platformer with enemy AI and collectibles
- Pixi.js Integration: Demonstrates ECS integration with rendering engines

The examples will be deployed to GitHub Pages on push to main/master branch.