### PR TITLE
feat: Allow uppercase letters in PR title checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -72,11 +72,11 @@ jobs:
             style
             build
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
+          subjectPattern: ^.+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.
+            is not empty.
 
   block-fixup:
     name: Block Fixup Commits


### PR DESCRIPTION
Updated the PR title check workflow to accept both uppercase and lowercase letters in the subject line. Removed the negative lookahead pattern that was blocking uppercase letters.