### PR TITLE
chore: Configure linters to flag unused imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,7 +5,8 @@
     "suspicious": "warn",
     "perf": "warn",
     "typescript/no-explicit-any": "warn",
-    "no-unused-vars": "warn"
+    "no-unused-vars": "error",
+    "import/no-duplicates": "error"
   },
   "categories": {
     "correctness": "error",
@@ -28,7 +29,7 @@
         "typescript/no-explicit-any": "warn",
         "typescript/no-extraneous-class": "off",
         "no-console": "off",
-        "no-unused-vars": "warn"
+        "no-unused-vars": "error"
       }
     },
     {

--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,8 @@
         "noUselessConstructor": "off"
       },
       "correctness": {
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
       },
       "style": {
         "noNonNullAssertion": "warn",


### PR DESCRIPTION
- Add Biome's noUnusedImports rule (error level) to catch unused imports
- Upgrade Oxlint's no-unused-vars from warn to error for stricter checking
- Add import/no-duplicates rule to Oxlint to prevent duplicate imports
- Update test file overrides to maintain error-level consistency

This ensures both Biome and Oxlint will catch unused imports, helping satisfy CodeQL requirements for code quality.

Verified both linters correctly flag unused imports with test cases.