### PR TITLE
chore!: Rename core package and update to v0.3.0

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,12 +31,14 @@ jobs:
         run: npm ci
 
       - name: Build core package
-        run: npm run build --workspace=core
+        run: npm run build --workspace=packages/core
 
       - name: Generate API documentation
         run: |
-          npm run docs:generate --workspace=core
-          npm run docs:generate --workspace=utils
+          npm run docs:generate --workspace=packages/core
+          npm run docs:generate --workspace=packages/math
+          npm run docs:generate --workspace=packages/graphics
+          npm run docs:generate --workspace=packages/testing
 
       - name: Build examples
         run: npm run build --workspace=examples
@@ -46,9 +48,13 @@ jobs:
           mkdir -p ./deploy
           cp -r ./examples/dist/* ./deploy/ 2>/dev/null || :
           mkdir -p ./deploy/api
-          cp -r ./core/docs/* ./deploy/api/
-          mkdir -p ./deploy/api/utils
-          cp -r ./utils/docs/* ./deploy/api/utils/
+          cp -r ./packages/core/docs/* ./deploy/api/
+          mkdir -p ./deploy/api/math
+          cp -r ./packages/math/docs/* ./deploy/api/math/
+          mkdir -p ./deploy/api/graphics
+          cp -r ./packages/graphics/docs/* ./deploy/api/graphics/
+          mkdir -p ./deploy/api/testing
+          cp -r ./packages/testing/docs/* ./deploy/api/testing/
           echo "Creating index redirect..."
           cat > ./deploy/index.html << 'EOF'
           <!DOCTYPE html>
@@ -101,9 +107,19 @@ jobs:
                 <p>Complete API documentation for OrionECS engine, entities, systems, and queries</p>
               </a>
 
-              <a href="./api/utils/" class="link-card">
-                <h2>🔧 Utils API Reference</h2>
-                <p>Utility classes documentation: Vector2, Bounds, Color, Mesh, and more</p>
+              <a href="./api/math/" class="link-card">
+                <h2>🔢 Math API Reference</h2>
+                <p>Mathematical utilities: Vector2, Bounds, and geometric operations</p>
+              </a>
+
+              <a href="./api/graphics/" class="link-card">
+                <h2>🎨 Graphics API Reference</h2>
+                <p>Graphics primitives: Color, Mesh, Vertex, and rendering utilities</p>
+              </a>
+
+              <a href="./api/testing/" class="link-card">
+                <h2>🧪 Testing API Reference</h2>
+                <p>Testing utilities: TestEngineBuilder, assertions, mocks, and test helpers</p>
               </a>
 
               <a href="https://github.com/tyevco/OrionECS" class="link-card">

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"No tests for examples\" && exit 0"
   },
   "dependencies": {
-    "orion-ecs": "*",
+    "@orion-ecs/core": "*",
     "pixi.js": "^8.0.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
       "name": "@orionecs/examples",
       "version": "2.0.0",
       "dependencies": {
-        "orion-ecs": "*",
+        "@orion-ecs/core": "*",
         "pixi.js": "^8.0.0"
       },
       "devDependencies": {
@@ -4911,6 +4911,10 @@
     },
     "node_modules/@orion-ecs/canvas2d-renderer": {
       "resolved": "plugins/canvas2d-renderer",
+      "link": true
+    },
+    "node_modules/@orion-ecs/core": {
+      "resolved": "packages/core",
       "link": true
     },
     "node_modules/@orion-ecs/debug-visualizer": {
@@ -10917,10 +10921,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/orion-ecs": {
-      "resolved": "packages/core",
-      "link": true
-    },
     "node_modules/orionecs-tutorial-01-first-ecs-project": {
       "resolved": "tutorials/01-first-ecs-project",
       "link": true
@@ -14006,8 +14006,8 @@
       }
     },
     "packages/core": {
-      "name": "orion-ecs",
-      "version": "0.2.0",
+      "name": "@orion-ecs/core",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -14035,7 +14035,7 @@
     },
     "packages/graphics": {
       "name": "@orion-ecs/graphics",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@orion-ecs/math": "file:../math"
@@ -14051,7 +14051,7 @@
     },
     "packages/math": {
       "name": "@orion-ecs/math",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -14064,19 +14064,19 @@
     },
     "packages/testing": {
       "name": "@orion-ecs/testing",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
+        "@orion-ecs/core": "file:../core",
         "@types/jest": "^30.0.0",
         "jest": "30.2.0",
-        "orion-ecs": "file:../core",
         "ts-jest": "^29.4.5",
         "tsup": "^8.0.0",
         "typedoc": "^0.28.14",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "orion-ecs": "^0.2.0"
+        "@orion-ecs/core": "^0.3.0"
       }
     },
     "packages/utils": {
@@ -14095,48 +14095,48 @@
     },
     "plugins/canvas2d-renderer": {
       "name": "@orion-ecs/canvas2d-renderer",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
+        "@orion-ecs/core": "*",
         "@orion-ecs/graphics": "*",
-        "@orion-ecs/math": "*",
-        "orion-ecs": "*"
+        "@orion-ecs/math": "*"
       }
     },
     "plugins/debug-visualizer": {
       "name": "@orion-ecs/debug-visualizer",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
+        "@orion-ecs/core": "*",
         "@orion-ecs/graphics": "*",
-        "@orion-ecs/math": "*",
-        "orion-ecs": "*"
+        "@orion-ecs/math": "*"
       }
     },
     "plugins/input-manager": {
       "name": "@orion-ecs/input-manager",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "@orion-ecs/math": "*",
-        "orion-ecs": "*"
+        "@orion-ecs/core": "*",
+        "@orion-ecs/math": "*"
       }
     },
     "plugins/interaction-system": {
       "name": "@orion-ecs/interaction-system",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
@@ -14144,58 +14144,58 @@
       },
       "peerDependencies": {
         "@orion-ecs/canvas2d-renderer": "*",
+        "@orion-ecs/core": "*",
         "@orion-ecs/input-manager": "*",
-        "@orion-ecs/math": "*",
-        "orion-ecs": "*"
+        "@orion-ecs/math": "*"
       }
     },
     "plugins/physics": {
       "name": "@orion-ecs/physics",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "orion-ecs": "*"
+        "@orion-ecs/core": "*"
       }
     },
     "plugins/profiling": {
       "name": "@orion-ecs/profiling",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "orion-ecs": "*"
+        "@orion-ecs/core": "*"
       }
     },
     "plugins/resource-manager": {
       "name": "@orion-ecs/resource-manager",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "orion-ecs": "*"
+        "@orion-ecs/core": "*"
       }
     },
     "plugins/spatial-partition": {
       "name": "@orion-ecs/spatial-partition",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
-        "@orion-ecs/math": "*",
-        "orion-ecs": "*"
+        "@orion-ecs/core": "*",
+        "@orion-ecs/math": "*"
       }
     },
     "testing": {
@@ -14221,7 +14221,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "orion-ecs": "*"
+        "@orion-ecs/core": "*"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "orion-ecs",
-  "version": "0.2.0",
+  "name": "@orion-ecs/core",
+  "version": "0.3.0",
   "description": "A lightweight and flexible Entity Component System (ECS) framework written in TypeScript",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/graphics",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Graphics primitives for OrionECS (Color, Mesh, Vertex)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/math",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Mathematical utilities for OrionECS (Vector2, Bounds)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/testing",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Testing utilities for OrionECS - comprehensive tools for testing ECS systems and components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -35,12 +35,12 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "^0.2.0"
+    "@orion-ecs/core": "^0.3.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "jest": "30.2.0",
-    "orion-ecs": "file:../core",
+    "@orion-ecs/core": "file:../core",
     "ts-jest": "^29.4.5",
     "tsup": "^8.0.0",
     "typedoc": "^0.28.14",

--- a/packages/testing/src/testing.spec.ts
+++ b/packages/testing/src/testing.spec.ts
@@ -2,8 +2,8 @@
  * Tests for OrionECS Testing Utilities
  */
 
-import type { Entity, ComponentIdentifier, EntityPrefab } from 'orion-ecs';
-import { Engine } from 'orion-ecs';
+import type { ComponentIdentifier, Entity, EntityPrefab } from '@orion-ecs/core';
+import { Engine } from '@orion-ecs/core';
 import {
     assertEngineClean,
     createMockComponent,

--- a/packages/testing/src/testing.ts
+++ b/packages/testing/src/testing.ts
@@ -5,8 +5,14 @@
  * @module testing
  */
 
-import type { Entity, ComponentArgs, ComponentIdentifier, SystemProfile, Engine } from 'orion-ecs';
-import { EngineBuilder } from 'orion-ecs';
+import type {
+    ComponentArgs,
+    ComponentIdentifier,
+    Engine,
+    Entity,
+    SystemProfile,
+} from '@orion-ecs/core';
+import { EngineBuilder } from '@orion-ecs/core';
 
 /**
  * TestEngineBuilder provides a preconfigured engine builder optimized for testing.

--- a/plugins/canvas2d-renderer/package.json
+++ b/plugins/canvas2d-renderer/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/canvas2d-renderer",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Canvas2D rendering plugin for OrionECS with camera and sprite support",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -33,7 +33,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*",
+    "@orion-ecs/core": "*",
     "@orion-ecs/math": "*",
     "@orion-ecs/graphics": "*"
   },

--- a/plugins/debug-visualizer/package.json
+++ b/plugins/debug-visualizer/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/debug-visualizer",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Debug visualization plugin for OrionECS with canvas rendering for physics, colliders, and transforms",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -32,7 +32,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*",
+    "@orion-ecs/core": "*",
     "@orion-ecs/math": "*",
     "@orion-ecs/graphics": "*"
   },

--- a/plugins/input-manager/package.json
+++ b/plugins/input-manager/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/input-manager",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Input handling plugin for OrionECS with mouse and keyboard support",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -32,7 +32,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*",
+    "@orion-ecs/core": "*",
     "@orion-ecs/math": "*"
   },
   "devDependencies": {

--- a/plugins/interaction-system/package.json
+++ b/plugins/interaction-system/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/interaction-system",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Interaction system plugin for OrionECS with click, drag, and selection support",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -32,7 +32,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*",
+    "@orion-ecs/core": "*",
     "@orion-ecs/math": "*",
     "@orion-ecs/input-manager": "*",
     "@orion-ecs/canvas2d-renderer": "*"

--- a/plugins/physics/package.json
+++ b/plugins/physics/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/physics",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Physics simulation plugin for OrionECS with rigid body dynamics and collision detection",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -31,7 +31,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*"
+    "@orion-ecs/core": "*"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/plugins/profiling/package.json
+++ b/plugins/profiling/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/profiling",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Performance profiling plugin for OrionECS with real-time metrics and visualization",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -31,7 +31,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*"
+    "@orion-ecs/core": "*"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/plugins/resource-manager/package.json
+++ b/plugins/resource-manager/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/resource-manager",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Asset and resource management plugin for OrionECS with loading, caching, and lifecycle management",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -31,7 +31,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*"
+    "@orion-ecs/core": "*"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/plugins/spatial-partition/package.json
+++ b/plugins/spatial-partition/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@orion-ecs/spatial-partition",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Spatial partitioning plugin for OrionECS with quadtree and grid-based collision detection",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [
@@ -32,7 +32,7 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "orion-ecs": "*",
+    "@orion-ecs/core": "*",
     "@orion-ecs/math": "*"
   },
   "devDependencies": {

--- a/tutorials/01-first-ecs-project/package.json
+++ b/tutorials/01-first-ecs-project/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "orion-ecs": "*"
+    "@orion-ecs/core": "*"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/tutorials/01-first-ecs-project/src/index.ts
+++ b/tutorials/01-first-ecs-project/src/index.ts
@@ -10,7 +10,7 @@
  * - Running a basic update loop
  */
 
-import { EngineBuilder } from 'orion-ecs';
+import { EngineBuilder, EntityDef } from '@orion-ecs/core';
 import { Position, Velocity, Renderable } from './components';
 
 // Build the engine with debug mode enabled for helpful error messages
@@ -66,7 +66,7 @@ engine.createSystem(
     all: [Position, Velocity]  // Query: entities with both components
   },
   {
-    act: (_entity, ...components) => {
+    act: (_entity: EntityDef, ...components: any[]) => {
       const [position, velocity] = components as [Position, Velocity];
       // Update position based on velocity
       position.x += velocity.x;
@@ -95,7 +95,7 @@ engine.createSystem(
       console.log('║' + ' OrionECS Tutorial 1: Your First ECS Project '.padEnd(48) + '║');
       console.log('╠' + '═'.repeat(48) + '╣');
     },
-    act: (entity, ...components) => {
+    act: (entity: EntityDef, ...components: any[]) => {
       const [position, renderable] = components as [Position, Renderable];
       // Simple console rendering
       const x = Math.round(position.x).toString().padStart(3);
@@ -142,7 +142,7 @@ function update() {
 
     // Display final state using a manual query
     const entities = engine.query().withAll(Position).build().getEntitiesArray();
-    entities.forEach(entity => {
+    entities.forEach((entity: EntityDef) => {
       const pos = entity.getComponent(Position)!;
       const x = Math.round(pos.x).toString().padStart(3);
       const y = Math.round(pos.y).toString().padStart(3);


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** This PR renames the core package from `orion-ecs` to `@orion-ecs/core` for consistency with the monorepo structure and updates all packages to version 0.3.0.

### Key Changes

- **Package Rename:** `orion-ecs` → `@orion-ecs/core` (BREAKING)
- **Version Bump:** All packages updated from 0.2.0/1.0.0 → 0.3.0
- **Build Fixes:** Corrected package.json exports ordering (types → import → require) across 11 packages
- **Dependency Updates:** Updated all plugin peerDependencies and package dependencies
- **Workflow Updates:** Fixed GitHub Actions workflow for new `packages/` directory structure
- **Documentation:** Added testing framework documentation to GitHub Pages deployment
- **Tutorial Fixes:** Resolved TypeScript strict mode errors in Tutorial 01

### Files Changed

- 14 package.json files (exports ordering, versions, dependencies)
- 3 code files (import statements, type annotations)
- 1 workflow file (package paths, testing docs deployment)
- 1 package-lock.json (dependency updates)

**Total:** 19 files changed, 120 insertions(+), 98 deletions(-)

## Test Plan

- [x] All 14/14 packages build successfully
- [x] TypeScript type checking passes without errors
- [x] Linter runs successfully (warnings are intentional)
- [x] Tutorial 01 builds and runs without errors
- [x] Pre-commit hooks pass (biome, oxlint)
- [x] Package dependencies properly linked after `npm install`

## Migration Guide

Users will need to update their imports:

```typescript
// Before
import { EngineBuilder } from 'orion-ecs';

// After
import { EngineBuilder } from '@orion-ecs/core';
```

And update package.json dependencies:

```json
{
  "dependencies": {
    "@orion-ecs/core": "^0.3.0"
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)