### PR TITLE
chore: Fix CodeQL analysis configuration issues

### DIFF
--- a/examples/integrations/react-example.tsx
+++ b/examples/integrations/react-example.tsx
@@ -122,7 +122,7 @@ interface InventoryItem {
 class PlayerInfo {
   constructor(
     public name: string = 'Player',
-    public class: string = 'Warrior',
+    public playerClass: string = 'Warrior',
   ) {}
 }
 
@@ -493,7 +493,7 @@ const PlayerHUD: FC<PlayerHUDProps> = ({ playerEntity }) => {
     'div',
     { style: containerStyle },
     React.createElement('div', { style: titleStyle }, info?.name || 'Player'),
-    React.createElement('div', { style: { fontSize: '12px', color: '#94a3b8' } }, info?.class),
+    React.createElement('div', { style: { fontSize: '12px', color: '#94a3b8' } }, info?.playerClass),
     React.createElement(
       'div',
       { style: sectionStyle },


### PR DESCRIPTION
The 'class' keyword is reserved in JavaScript/TypeScript and cannot be used as an identifier. This was causing CodeQL syntax errors during analysis. Renamed to 'playerClass' to fix the issue.