### PR TITLE
feat: Unified multi-package API documentation with examples

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,11 +34,7 @@ jobs:
         run: npm run build
 
       - name: Generate API documentation
-        run: |
-          npm run docs:generate --workspace=packages/core
-          npm run docs:generate --workspace=packages/math
-          npm run docs:generate --workspace=packages/graphics
-          npm run docs:generate --workspace=packages/testing
+        run: npm run docs:generate
 
       - name: Build examples
         run: npm run build --workspace=examples
@@ -51,15 +47,9 @@ jobs:
           mkdir -p ./deploy/examples
           cp -r ./examples/dist/* ./deploy/examples/ 2>/dev/null || :
 
-          # Copy API documentation
+          # Copy unified API documentation (all packages in one viewer)
           mkdir -p ./deploy/api
-          cp -r ./packages/core/docs/* ./deploy/api/
-          mkdir -p ./deploy/api/math
-          cp -r ./packages/math/docs/* ./deploy/api/math/
-          mkdir -p ./deploy/api/graphics
-          cp -r ./packages/graphics/docs/* ./deploy/api/graphics/
-          mkdir -p ./deploy/api/testing
-          cp -r ./packages/testing/docs/* ./deploy/api/testing/
+          cp -r ./api-docs/* ./deploy/api/
 
           echo "Creating landing page..."
           cat > ./deploy/index.html << 'EOF'
@@ -182,34 +172,13 @@ jobs:
 
                 <div class="section">
                   <h2><span>📚</span> API Documentation</h2>
-                  <p>Complete API reference for all OrionECS packages</p>
+                  <p>Unified API reference for all OrionECS packages with cross-navigation</p>
                   <div class="links">
                     <a href="./api/" class="link">
-                      <span class="icon">⚙️</span>
+                      <span class="icon">📖</span>
                       <div class="text">
-                        <div class="title">Core API</div>
-                        <div class="desc">Engine, entities, systems, queries, and components</div>
-                      </div>
-                    </a>
-                    <a href="./api/math/" class="link">
-                      <span class="icon">🔢</span>
-                      <div class="text">
-                        <div class="title">Math API</div>
-                        <div class="desc">Vector2, Bounds, and geometric operations</div>
-                      </div>
-                    </a>
-                    <a href="./api/graphics/" class="link">
-                      <span class="icon">🎨</span>
-                      <div class="text">
-                        <div class="title">Graphics API</div>
-                        <div class="desc">Color, Mesh, Vertex, and rendering utilities</div>
-                      </div>
-                    </a>
-                    <a href="./api/testing/" class="link">
-                      <span class="icon">🧪</span>
-                      <div class="text">
-                        <div class="title">Testing API</div>
-                        <div class="desc">TestEngineBuilder, assertions, and mocks</div>
+                        <div class="title">Full API Reference</div>
+                        <div class="desc">All packages: Core, Math, Graphics, Testing, Plugin API</div>
                       </div>
                     </a>
                   </div>

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ FakesAssemblies/
 **/.turbo
 
 # Generated documentation
+/api-docs/
 core/docs/
 utils/docs/
 packages/*/docs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,8 @@
         "ts-jest": "^29.4.5",
         "tsup": "^8.5.1",
         "turbo": "^2.6.1",
+        "typedoc": "^0.28.14",
+        "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "^5.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "release": "npm run build && npm run test && changeset publish",
     "release:dry-run": "npm run build && npm run test && changeset publish --dry-run",
     "validate:packages": "npm run typecheck && npm run lint && npm run test && npm run build",
-    "validate:publish": "npm run validate:packages && npm run release:dry-run"
+    "validate:publish": "npm run validate:packages && npm run release:dry-run",
+    "docs:generate": "typedoc",
+    "docs:serve": "npx http-server docs -p 8080 -o"
   },
   "workspaces": [
     "packages/core",
@@ -65,6 +67,8 @@
     "ts-jest": "^29.4.5",
     "tsup": "^8.5.1",
     "turbo": "^2.6.1",
+    "typedoc": "^0.28.14",
+    "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "^5.9.3"
   },
   "lint-staged": {

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "**/node_modules/**",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.bench.ts",
+    "**/benchmarks/**",
+    "**/dist/**",
+    "**/coverage/**",
+    "examples/**",
+    "tutorials/**"
+  ]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPointStrategy": "resolve",
+  "entryPoints": [
+    "packages/core/src/index.ts",
+    "packages/math/src/index.ts",
+    "packages/graphics/src/index.ts",
+    "packages/testing/src/index.ts",
+    "packages/plugin-api/src/index.ts",
+    "plugins/canvas2d-renderer/src/index.ts",
+    "plugins/debug-visualizer/src/index.ts",
+    "plugins/decision-tree/src/index.ts",
+    "plugins/input-manager/src/index.ts",
+    "plugins/interaction-system/src/index.ts",
+    "plugins/physics/src/index.ts",
+    "plugins/profiling/src/index.ts",
+    "plugins/resource-manager/src/index.ts",
+    "plugins/spatial-partition/src/index.ts",
+    "plugins/state-machine/src/index.ts"
+  ],
+  "tsconfig": "tsconfig.docs.json",
+  "out": "api-docs",
+  "name": "OrionECS API Documentation",
+  "readme": "README.md",
+  "includeVersion": true,
+  "sort": ["source-order", "required-first", "kind"],
+  "categorizeByGroup": true,
+  "searchInComments": true,
+  "searchInDocuments": true,
+  "navigation": {
+    "includeCategories": true,
+    "includeGroups": true,
+    "includeFolders": true
+  },
+  "exclude": [
+    "**/node_modules/**",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.bench.ts",
+    "**/benchmarks/**"
+  ],
+  "skipErrorChecking": true,
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "excludeInternal": false,
+  "treatWarningsAsErrors": false,
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "notDocumented": false
+  },
+  "cleanOutputDir": true,
+  "githubPages": true,
+  "hideGenerator": false,
+  "visibilityFilters": {
+    "protected": true,
+    "private": false,
+    "inherited": true,
+    "external": false
+  }
+}


### PR DESCRIPTION
Add comprehensive GitHub Pages deployment with unified API docs and examples:

API Documentation:
- Create root typedoc.json with all packages and plugins (15 total)
- Use "resolve" entry point strategy for clean builds
- Add tsconfig.docs.json to exclude test/spec files
- Single unified viewer with sidebar navigation between all modules

Packages: core, math, graphics, testing, plugin-api Plugins: canvas2d-renderer, debug-visualizer, decision-tree,
         input-manager, interaction-system, physics, profiling,
         resource-manager, spatial-partition, state-machine

Examples & Games:
- Enable vite build for examples with all HTML entry points
- Games: Asteroids, Platformer, Tower Defense, Void Vanguard, RTS Demo, Space Shooter
- Integrations: Pixi.js, Three.js

Deploy Structure:
- /api/ - Unified TypeDoc API documentation
- /examples/ - Playable games and integration demos
- Landing page with links to both sections