### PR TITLE
refactor: Enhance nightly review with type-safety and ECS principles

### DIFF
--- a/.github/workflows/claude-nightly-review.yml
+++ b/.github/workflows/claude-nightly-review.yml
@@ -70,6 +70,8 @@ jobs:
             - ❌ Runtime type checking that could be compile-time
             - ❌ Use of `any`, `unknown` without proper narrowing
             - ❌ Type assertions to bypass the type system
+            - ❌ **Global state in static variables** - Use `engine.setSingleton()` instead
+            - ❌ Module-level mutable state - State should live in ECS (singletons or components)
 
             ## Review Scope
 
@@ -91,6 +93,8 @@ jobs:
             - Inheritance hierarchies instead of composition
             - Tight coupling between components
             - Core modifications that should be plugins
+            - **Static or module-level state** - Should use `engine.setSingleton()` for global state
+            - Mutable state outside the ECS (globals, statics, module variables)
 
             ### 3. Code Smells
             - Dead code or unused exports


### PR DESCRIPTION
## Summary

Enhances the nightly code review workflow (added in #242) to enforce OrionECS-specific architectural and type-safety requirements.

## Changes

### Type Safety Enforcement (Highest Priority)
- Flag any `any` types or unnecessary type assertions
- Enforce strict TypeScript compliance (`noImplicitAny`)
- Verify generic type flow (EngineAccumulator pattern)
- Check for type guards, discriminated unions, template literal types
- Identify runtime checks that should be compile-time

### ECS Architecture Principles (Critical)
- Composition over inheritance enforcement
- Data-oriented design (components = data only, systems = logic only)
- No behavior/methods in components
- Systems must use the query system
- Plugin architecture respect
- **Global state detection** - Flag static/module-level state, recommend `engine.setSingleton()`

### Anti-Pattern Detection

Added detection for:
- ❌ Components with business logic methods
- ❌ Systems that don't use queries
- ❌ Type erasure or lost type information
- ❌ Runtime type checks that should be compile-time
- ❌ **Global state in static variables** - Use `engine.setSingleton()` instead
- ❌ **Module-level mutable state** - State should live in ECS

### Reorganized Review Categories

Prioritized by importance:
1. **Type Safety Violations** (CRITICAL)
2. **ECS Architecture Violations** (HIGH) - including static state detection
3. Code Smells
4. Potential Bugs
5. Security Issues
6. Performance Issues
7. Architecture & Design
8. Documentation

## Why These Changes

OrionECS is a **strict type-safe ECS framework**. The nightly review must enforce:
- Type safety as a core principle (no `any`, proper generics)
- ECS architectural patterns (composition, data-oriented design)
- Proper global state management (singletons, not statics)

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test manually via Actions tab
- [ ] Confirm review prioritizes type safety and ECS violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)