### PR TITLE
feat: Enable Claude to manage issues/PRs (maintainers only)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Enhances the `claude.yml` workflow to allow Claude to create, edit, and comment on issues and PRs when tagged with `@claude` - restricted to repository maintainers only.

## Changes

### Enhanced Permissions
- Updated `issues: read` → `issues: write`
- Updated `pull-requests: read` → `pull-requests: write`
- Added write permissions to `additional_permissions` config

### Enabled GitHub CLI Commands
- Added `claude_args: '--allowed-tools "Bash(gh issue *),Bash(gh pr *)"'`
- Claude can now use all `gh issue` and `gh pr` commands

### Security: Maintainer-Only Access
- Added `author_association` checks for all event types
- Only users with `OWNER`, `MEMBER`, or `COLLABORATOR` roles can trigger @claude
- Prevents unauthorized workflow usage and resource consumption

## What Claude Can Now Do (Maintainers Only)

When maintainers tag `@claude` in issues or PRs:
- ✅ Create new issues with `gh issue create`
- ✅ Edit existing issues with `gh issue edit`
- ✅ Comment on issues with `gh issue comment`
- ✅ Comment on PRs with `gh pr comment`
- ✅ Update PR descriptions with `gh pr edit`
- ✅ Use all GitHub CLI issue/PR commands

## Security

The workflow will **only run** if the user triggering it has one of:
- `OWNER` - Repository owner
- `MEMBER` - Organization member
- `COLLABORATOR` - Repository collaborator

External contributors and regular users **cannot** trigger the workflow.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test with maintainer account - should work
- [ ] Test with non-maintainer account - should not run
- [ ] Confirm Claude can create/edit/comment on issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)