### PR TITLE
fix: Replace any with unknown in ComponentIdentifier

### DIFF
--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -1080,7 +1080,7 @@ export class CommandBuffer {
                         // If constructor args don't match, try creating empty and assigning
                         entity.addComponent(change.componentType);
                         const component = entity.getComponent(change.componentType);
-                        Object.assign(component, componentData);
+                        Object.assign(component as object, componentData);
                     }
                 }
             } else {

--- a/packages/core/src/definitions.ts
+++ b/packages/core/src/definitions.ts
@@ -29,7 +29,7 @@ type SystemMessage = PluginApiSystemMessage;
  * @typeParam T - The instance type of the component
  * @public
  */
-export type ComponentIdentifier<T = any> = new (...args: any[]) => T;
+export type ComponentIdentifier<T = unknown> = new (...args: any[]) => T;
 
 /**
  * Extract constructor parameter types from a component identifier.
@@ -341,7 +341,7 @@ export type ChildRemovedListener = (event: ChildRemovedEvent) => void;
 export type ParentChangedListener = (event: ParentChangedEvent) => void;
 
 // Enhanced system options with profiling and lifecycle hooks
-export interface SystemOptions<C extends readonly any[] = any[]> {
+export interface SystemOptions<C extends readonly unknown[] = unknown[]> {
     act?: (entity: EntityDef, ...components: C) => void;
     before?: () => void;
     after?: () => void;
@@ -439,7 +439,8 @@ export interface SystemOptions<C extends readonly any[] = any[]> {
     watchHierarchy?: boolean;
 }
 
-export type SystemType<T extends readonly any[] = any[]> = SystemOptions<T> & Partial<EngineEvents>;
+export type SystemType<T extends readonly unknown[] = unknown[]> = SystemOptions<T> &
+    Partial<EngineEvents>;
 
 // Enhanced engine events
 export interface EngineEvents {
@@ -662,7 +663,7 @@ export interface MemoryStats {
 }
 
 // Component validation
-export interface ComponentValidator<T = any> {
+export interface ComponentValidator<T = unknown> {
     validate(component: T): boolean | string;
     dependencies?: ComponentIdentifier[];
     conflicts?: ComponentIdentifier[];

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1532,7 +1532,7 @@ export class Engine {
                     } catch {
                         // If that fails, create empty and assign properties
                         const component = new componentType();
-                        Object.assign(component, componentData);
+                        Object.assign(component as object, componentData);
                         this.componentManager.setSingleton(componentType, component);
                     }
                 }

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -125,7 +125,7 @@ export interface SystemProfile {
  *
  * @public
  */
-export type ComponentIdentifier<T = any> = new (...args: any[]) => T;
+export type ComponentIdentifier<T = unknown> = new (...args: any[]) => T;
 
 /**
  * Component validator for runtime validation of component data.
@@ -134,7 +134,7 @@ export type ComponentIdentifier<T = any> = new (...args: any[]) => T;
  *
  * @public
  */
-export interface ComponentValidator<T = any> {
+export interface ComponentValidator<T = unknown> {
     /** Validate the component, returning true or an error message */
     validate(component: T): boolean | string;
     /** Other components that must be present on the entity */


### PR DESCRIPTION
Improve type safety at the framework's foundation by changing the default type parameter of ComponentIdentifier from 'any' to 'unknown'.

Changes:
- ComponentIdentifier<T = any> → ComponentIdentifier<T = unknown>
- ComponentValidator<T = any> → ComponentValidator<T = unknown>
- SystemOptions and SystemType defaults updated for consistency
- Fixed Object.assign calls that needed explicit casts to 'object'

This enforces that users must explicitly specify component types when using ComponentIdentifier without a type parameter, enabling better compile-time type safety and IDE support.

Fixes #249