### PR TITLE
fix: Fix static state in Entity ID generation

### DIFF
--- a/packages/core/src/archetype.spec.ts
+++ b/packages/core/src/archetype.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { Archetype, ArchetypeManager } from './archetype';
-import { Entity, EventEmitter } from './core';
+import { Entity, EntityIdGenerator, EventEmitter } from './core';
 import { ComponentManager } from './managers';
 
 // Test components
@@ -103,12 +103,14 @@ describe('Archetype', () => {
     describe('entity management', () => {
         let componentManager: ComponentManager;
         let eventEmitter: EventEmitter;
+        let idGenerator: EntityIdGenerator;
         let entity: Entity;
 
         beforeEach(() => {
             componentManager = new ComponentManager();
             eventEmitter = new EventEmitter();
-            entity = Entity.create(componentManager, eventEmitter);
+            idGenerator = new EntityIdGenerator();
+            entity = Entity.create(componentManager, eventEmitter, idGenerator);
         });
 
         it('should add entity with components', () => {
@@ -127,7 +129,7 @@ describe('Archetype', () => {
             components1.set(Position, new Position(10, 20));
             components1.set(Velocity, new Velocity(1, 2));
 
-            const entity2 = Entity.create(componentManager, eventEmitter);
+            const entity2 = Entity.create(componentManager, eventEmitter, idGenerator);
             const components2 = new Map();
             components2.set(Position, new Position(30, 40));
             components2.set(Velocity, new Velocity(3, 4));
@@ -173,7 +175,7 @@ describe('Archetype', () => {
         });
 
         it('should iterate over entities efficiently', () => {
-            const entity2 = Entity.create(componentManager, eventEmitter);
+            const entity2 = Entity.create(componentManager, eventEmitter, idGenerator);
 
             const components1 = new Map();
             components1.set(Position, new Position(10, 20));
@@ -213,11 +215,13 @@ describe('ArchetypeManager', () => {
     let archetypeManager: ArchetypeManager;
     let componentManager: ComponentManager;
     let eventEmitter: EventEmitter;
+    let idGenerator: EntityIdGenerator;
 
     beforeEach(() => {
         archetypeManager = new ArchetypeManager();
         componentManager = new ComponentManager();
         eventEmitter = new EventEmitter();
+        idGenerator = new EntityIdGenerator();
     });
 
     describe('getOrCreateArchetype', () => {
@@ -250,7 +254,7 @@ describe('ArchetypeManager', () => {
         let entity: Entity;
 
         beforeEach(() => {
-            entity = Entity.create(componentManager, eventEmitter);
+            entity = Entity.create(componentManager, eventEmitter, idGenerator);
         });
 
         it('should add entity to archetype', () => {
@@ -349,7 +353,7 @@ describe('ArchetypeManager', () => {
         });
 
         it('should provide memory statistics', () => {
-            const entity = Entity.create(componentManager, eventEmitter);
+            const entity = Entity.create(componentManager, eventEmitter, idGenerator);
             const archetype = archetypeManager.getOrCreateArchetype([Position]);
             const components = new Map();
             components.set(Position, new Position(10, 20));

--- a/packages/core/src/engine.spec.ts
+++ b/packages/core/src/engine.spec.ts
@@ -122,6 +122,33 @@ describe('Engine v2 - Composition Architecture', () => {
             expect(engine.getAllEntities()).toHaveLength(0);
         });
 
+        test('should isolate entity IDs between independent engine instances', () => {
+            // Create two separate engine instances
+            const engine1 = new EngineBuilder().build();
+            const engine2 = new EngineBuilder().build();
+
+            // Create entities in both engines
+            const entity1A = engine1.createEntity('Engine1_EntityA');
+            const entity1B = engine1.createEntity('Engine1_EntityB');
+            const entity2A = engine2.createEntity('Engine2_EntityA');
+            const entity2B = engine2.createEntity('Engine2_EntityB');
+
+            // Both engines should start with numeric ID 1
+            // This proves ID generation is per-engine, not global static
+            expect(entity1A.numericId).toBe(1);
+            expect(entity1B.numericId).toBe(2);
+            expect(entity2A.numericId).toBe(1);
+            expect(entity2B.numericId).toBe(2);
+
+            // IDs should be independent - creating more entities in engine1
+            // should not affect engine2's next ID
+            const entity1C = engine1.createEntity('Engine1_EntityC');
+            const entity2C = engine2.createEntity('Engine2_EntityC');
+
+            expect(entity1C.numericId).toBe(3);
+            expect(entity2C.numericId).toBe(3);
+        });
+
         test('should create multiple empty entities', () => {
             const entities = engine.createEntities(10);
             expect(entities.length).toBe(10);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
     ARCHETYPE_STORAGE_INDEX,
     ComponentArray,
     Entity,
+    EntityIdGenerator,
     EntityManager,
     EventEmitter,
     EventSubscriptionManager,


### PR DESCRIPTION
…rator

This fixes a critical issue where the Entity class used a static _nextId field for ID generation, which violated ECS principles by introducing global state shared across all engine instances.

Changes:
- Add EntityIdGenerator class for per-engine ID generation
- Modify Entity constructor to accept an idGenerator parameter
- Update EntityManager to create and use its own EntityIdGenerator
- Export EntityIdGenerator from package index
- Update archetype tests to use EntityIdGenerator
- Add test for multi-engine ID isolation

This ensures:
- Multiple engine instances have isolated ID counters
- Test isolation is maintained between test suites
- No ID collisions can occur between engines