### PR TITLE
fix: Improve type safety across components

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -483,6 +483,7 @@ export class ComponentArray<T> {
  *
  * @public
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Query<C extends readonly any[] = any[]> {
     private matchingEntities: Set<Entity> = new Set();
     private cachedArray: Entity[] = [];
@@ -500,6 +501,7 @@ export class Query<C extends readonly any[] = any[]> {
     private _lastMatchCount: number = 0;
     private _cacheHits: number = 0;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(
         public options: QueryOptions<any>,
         archetypeManager?: ArchetypeManager
@@ -691,9 +693,12 @@ export class Query<C extends readonly any[] = any[]> {
 /**
  * Fluent query builder for constructing complex queries
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class QueryBuilder<C extends readonly any[] = any[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private options: QueryOptions<any> = {};
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(private createQueryFn: (options: QueryOptions<any>) => Query<C>) {}
 
     /**
@@ -2253,7 +2258,7 @@ export class MessageBus {
         };
     }
 
-    publish(messageType: string, data: any, sender?: string): void {
+    publish(messageType: string, data: unknown, sender?: string): void {
         const message: SystemMessage = {
             type: messageType,
             data,
@@ -2299,14 +2304,14 @@ export class MessageBus {
  * Uses CircularBuffer for O(1) event history insertion instead of O(n) shift operations.
  */
 export class EventEmitter {
-    private listeners: Map<string, Set<(...args: any[]) => void>> = new Map();
-    private eventHistory: CircularBuffer<{ event: string; args: any[]; timestamp: number }>;
+    private listeners: Map<string, Set<(...args: unknown[]) => void>> = new Map();
+    private eventHistory: CircularBuffer<{ event: string; args: unknown[]; timestamp: number }>;
 
     constructor(maxHistorySize: number = MAX_EVENT_HISTORY) {
         this.eventHistory = new CircularBuffer(maxHistorySize);
     }
 
-    on(event: string, callback: (...args: any[]) => void): () => void {
+    on(event: string, callback: (...args: unknown[]) => void): () => void {
         if (!this.listeners.has(event)) {
             this.listeners.set(event, new Set());
         }
@@ -2316,14 +2321,14 @@ export class EventEmitter {
         return () => this.off(event, callback);
     }
 
-    off(event: string, callback: (...args: any[]) => void): void {
+    off(event: string, callback: (...args: unknown[]) => void): void {
         const callbacks = this.listeners.get(event);
         if (callbacks) {
             callbacks.delete(callback);
         }
     }
 
-    emit(event: string, ...args: any[]): void {
+    emit(event: string, ...args: unknown[]): void {
         // O(1) insertion using CircularBuffer instead of O(n) shift()
         this.eventHistory.push({ event, args, timestamp: Date.now() });
 
@@ -2339,7 +2344,7 @@ export class EventEmitter {
         }
     }
 
-    getEventHistory(): Array<{ event: string; args: any[]; timestamp: number }> {
+    getEventHistory(): Array<{ event: string; args: unknown[]; timestamp: number }> {
         return this.eventHistory.toArray();
     }
 }
@@ -2379,7 +2384,7 @@ export class EventSubscriptionManager {
     subscribe(
         emitter: EventEmitter,
         event: string,
-        callback: (...args: any[]) => void
+        callback: (...args: unknown[]) => void
     ): () => void {
         const unsubscribe = emitter.on(event, callback);
         this.unsubscribers.push(unsubscribe);
@@ -2471,17 +2476,20 @@ export class EntityManager {
         // Subscribe to entity changes to maintain tag index
         // Store unsubscribe functions for proper cleanup
         this._eventUnsubscribers.push(
-            eventEmitter.on('onComponentAdded', (entity: Entity) => {
+            eventEmitter.on('onComponentAdded', (...args: unknown[]) => {
+                const entity = args[0] as Entity;
                 this.updateEntityTags(entity);
             })
         );
         this._eventUnsubscribers.push(
-            eventEmitter.on('onComponentRemoved', (entity: Entity) => {
+            eventEmitter.on('onComponentRemoved', (...args: unknown[]) => {
+                const entity = args[0] as Entity;
                 this.updateEntityTags(entity);
             })
         );
         this._eventUnsubscribers.push(
-            eventEmitter.on('onTagChanged', (entity: Entity) => {
+            eventEmitter.on('onTagChanged', (...args: unknown[]) => {
+                const entity = args[0] as Entity;
                 this.updateEntityTags(entity);
             })
         );

--- a/packages/core/src/definitions.ts
+++ b/packages/core/src/definitions.ts
@@ -92,7 +92,7 @@ export interface ComponentLifecycle {
  * @typeParam T - The component type
  * @public
  */
-export interface ComponentChangeEvent<T = any> {
+export interface ComponentChangeEvent<T = unknown> {
     /** The entity that owns the modified component */
     entity: EntityDef;
     /** The type/class of the component that changed */
@@ -114,7 +114,7 @@ export interface ComponentChangeEvent<T = any> {
  * @typeParam T - The component type
  * @public
  */
-export interface ComponentAddedEvent<T = any> {
+export interface ComponentAddedEvent<T = unknown> {
     /** The entity that received the component */
     entity: EntityDef;
     /** The type/class of the component that was added */
@@ -134,7 +134,7 @@ export interface ComponentAddedEvent<T = any> {
  * @typeParam T - The component type
  * @public
  */
-export interface ComponentRemovedEvent<T = any> {
+export interface ComponentRemovedEvent<T = unknown> {
     /** The entity that the component was removed from */
     entity: EntityDef;
     /** The type/class of the component that was removed */
@@ -223,7 +223,7 @@ export type ComponentRemovedListener<T = any> = (event: ComponentRemovedEvent<T>
  * @typeParam T - The component type
  * @public
  */
-export interface SingletonSetEvent<T = any> {
+export interface SingletonSetEvent<T = unknown> {
     /** The type/class of the singleton component */
     componentType: ComponentIdentifier<T>;
     /** The previous value of the singleton (undefined if newly set) */
@@ -240,7 +240,7 @@ export interface SingletonSetEvent<T = any> {
  * @typeParam T - The component type
  * @public
  */
-export interface SingletonRemovedEvent<T = any> {
+export interface SingletonRemovedEvent<T = unknown> {
     /** The type/class of the singleton component that was removed */
     componentType: ComponentIdentifier<T>;
     /** The component instance that was removed */
@@ -730,7 +730,7 @@ export interface PluginContext {
     ): void;
 
     // Singleton component management
-    setSingleton<T>(type: ComponentIdentifier<T>, ...args: any[]): T;
+    setSingleton<T>(type: ComponentIdentifier<T>, ...args: unknown[]): T;
     getSingleton<T>(type: ComponentIdentifier<T>): T | undefined;
     hasSingleton<T>(type: ComponentIdentifier<T>): boolean;
     removeSingleton<T>(type: ComponentIdentifier<T>): T | undefined;
@@ -741,10 +741,10 @@ export interface PluginContext {
         queryOptions: QueryOptions<All>,
         options: SystemType<ComponentTypes<All>>,
         isFixedUpdate?: boolean
-    ): any; // System<ComponentTypes<All>>
+    ): unknown; // System<ComponentTypes<All>>
 
     // Query creation
-    createQuery<All extends readonly ComponentIdentifier[]>(options: QueryOptions<All>): any; // Query<ComponentTypes<All>>
+    createQuery<All extends readonly ComponentIdentifier[]>(options: QueryOptions<All>): unknown; // Query<ComponentTypes<All>>
 
     // Prefab registration and management
     registerPrefab(name: string, prefab: EntityPrefab): void;
@@ -757,7 +757,7 @@ export interface PluginContext {
     variantOfPrefab(
         baseName: string,
         overrides: {
-            components?: { [componentName: string]: any };
+            components?: { [componentName: string]: unknown };
             tags?: string[];
             children?: EntityPrefab[];
         },
@@ -765,13 +765,13 @@ export interface PluginContext {
     ): EntityPrefab;
 
     // Event system
-    on(event: string, callback: (...args: any[]) => void): () => void;
-    emit(event: string, ...args: any[]): void;
+    on(event: string, callback: (...args: unknown[]) => void): () => void;
+    emit(event: string, ...args: unknown[]): void;
 
     // Message bus
     messageBus: {
         subscribe(messageType: string, callback: (message: SystemMessage) => void): () => void;
-        publish(messageType: string, data: any, sender?: string): void;
+        publish(messageType: string, data: unknown, sender?: string): void;
     };
 
     // Allow plugins to extend the engine with custom APIs
@@ -781,7 +781,7 @@ export interface PluginContext {
     logger: Logger;
 
     // Get engine instance for advanced use cases
-    getEngine(): any; // Engine
+    getEngine(): unknown; // Engine
 }
 
 // Note: EnginePlugin, ExtractPluginExtensions, and InstalledPlugin are

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -631,7 +631,8 @@ export class Engine {
         // Subscribe to entity changes to update queries
         // Store unsubscribers for proper cleanup on destroy
         this.engineEventUnsubscribers.push(
-            this.eventEmitter.on('onComponentAdded', (entity: Entity) => {
+            this.eventEmitter.on('onComponentAdded', (...args: unknown[]) => {
+                const entity = args[0] as Entity;
                 if (this.inTransaction) {
                     this.pendingQueryUpdates.add(entity);
                 } else {
@@ -640,7 +641,8 @@ export class Engine {
             })
         );
         this.engineEventUnsubscribers.push(
-            this.eventEmitter.on('onComponentRemoved', (entity: Entity) => {
+            this.eventEmitter.on('onComponentRemoved', (...args: unknown[]) => {
+                const entity = args[0] as Entity;
                 if (this.inTransaction) {
                     this.pendingQueryUpdates.add(entity);
                 } else {
@@ -649,7 +651,8 @@ export class Engine {
             })
         );
         this.engineEventUnsubscribers.push(
-            this.eventEmitter.on('onTagChanged', (entity: Entity) => {
+            this.eventEmitter.on('onTagChanged', (...args: unknown[]) => {
+                const entity = args[0] as Entity;
                 if (this.inTransaction) {
                     this.pendingQueryUpdates.add(entity);
                 } else {
@@ -2133,11 +2136,11 @@ export class Engine {
             .map((entity) => entity.serialize());
 
         // Serialize singleton components
-        const singletons: { [componentName: string]: any } = {};
+        const singletons: { [componentName: string]: unknown } = {};
         const allSingletons = this.componentManager.getAllSingletons();
 
         for (const [componentType, component] of allSingletons) {
-            singletons[componentType.name] = { ...component };
+            singletons[componentType.name] = { ...(component as object) };
         }
 
         return {


### PR DESCRIPTION
Type safety improvements:
- Replace comment-based type documentation with proper imports for Archetype and ArchetypeManager types in Query class
- Add explicit eslint-disable comments for intentional 'any' usage in heterogeneous collections (component arrays, pools, systems, queries)
- Update event system callback types from 'any' to 'unknown' for better type safety at API boundaries
- Update definition interfaces to use 'unknown' defaults instead of 'any' for generic type parameters (ComponentChangeEvent, SingletonSetEvent, etc.)
- Update PluginContext interface to use 'unknown' for better type safety

The 'any' types are preserved with eslint-disable comments in internal storage maps where heterogeneous type storage is required, while public APIs maintain proper generic type inference.