### PR TITLE
fix: ECS Transform Component architecture violations

### DIFF
--- a/plugins/canvas2d-renderer/src/Canvas2DRendererPlugin.spec.ts
+++ b/plugins/canvas2d-renderer/src/Canvas2DRendererPlugin.spec.ts
@@ -126,18 +126,13 @@ describe('Canvas2DRendererPlugin', () => {
             expect(transform.scaleY).toBe(0.5);
         });
 
-        test('should provide position getter', () => {
+        test('should allow direct property access for position', () => {
             const transform = new Transform(50, 75);
-            const position = transform.position;
+            expect(transform.x).toBe(50);
+            expect(transform.y).toBe(75);
 
-            expect(position.x).toBe(50);
-            expect(position.y).toBe(75);
-        });
-
-        test('should update position via setPosition', () => {
-            const transform = new Transform();
-            transform.setPosition(100, 200);
-
+            transform.x = 100;
+            transform.y = 200;
             expect(transform.x).toBe(100);
             expect(transform.y).toBe(200);
         });

--- a/plugins/canvas2d-renderer/src/Canvas2DRendererPlugin.ts
+++ b/plugins/canvas2d-renderer/src/Canvas2DRendererPlugin.ts
@@ -28,15 +28,6 @@ export class Transform {
         public scaleX: number = 1,
         public scaleY: number = 1
     ) {}
-
-    public get position(): { x: number; y: number } {
-        return { x: this.x, y: this.y };
-    }
-
-    public setPosition(x: number, y: number): void {
-        this.x = x;
-        this.y = y;
-    }
 }
 
 /**

--- a/plugins/input-manager/src/InputManagerPlugin.ts
+++ b/plugins/input-manager/src/InputManagerPlugin.ts
@@ -10,11 +10,8 @@
  * Based on the prototypedestination project's input systems.
  */
 
-import type { Vector2 } from '@orion-ecs/math';
+import { Vector2 } from '@orion-ecs/math';
 import type { EnginePlugin, PluginContext } from '@orion-ecs/plugin-api';
-
-// Import utilities
-let Vector2Class: typeof Vector2;
 
 /**
  * Mouse button enum
@@ -156,19 +153,7 @@ export class InputAPI implements IInputAPI {
         }
 
         this.element = element;
-
-        // Ensure Vector2 is available
-        if (!Vector2Class) {
-            try {
-                const math = require('@orion-ecs/math');
-                Vector2Class = math.Vector2;
-            } catch {
-                console.error('[InputAPI] Could not load Vector2 utility');
-                return;
-            }
-        }
-
-        this.mousePosition = new Vector2Class(0, 0);
+        this.mousePosition = new Vector2(0, 0);
         this.setupEventListeners();
     }
 
@@ -248,7 +233,7 @@ export class InputAPI implements IInputAPI {
                 this.emit('drag', {
                     startPosition: this.dragStart.clone(),
                     currentPosition: this.mousePosition.clone(),
-                    deltaPosition: new Vector2Class(
+                    deltaPosition: new Vector2(
                         this.mousePosition.x - this.dragStart.x,
                         this.mousePosition.y - this.dragStart.y
                     ),
@@ -292,7 +277,7 @@ export class InputAPI implements IInputAPI {
             this.emit('dragend', {
                 startPosition: this.dragStart.clone(),
                 currentPosition: this.mousePosition.clone(),
-                deltaPosition: new Vector2Class(
+                deltaPosition: new Vector2(
                     this.mousePosition.x - this.dragStart.x,
                     this.mousePosition.y - this.dragStart.y
                 ),
@@ -424,7 +409,7 @@ export class InputAPI implements IInputAPI {
         return {
             startPosition: this.dragStart.clone(),
             currentPosition: this.mousePosition.clone(),
-            deltaPosition: new Vector2Class(
+            deltaPosition: new Vector2(
                 this.mousePosition.x - this.dragStart.x,
                 this.mousePosition.y - this.dragStart.y
             ),
@@ -530,14 +515,6 @@ export class InputManagerPlugin implements EnginePlugin<{ input: IInputAPI }> {
     private api = new InputAPI();
 
     install(context: PluginContext): void {
-        // Dynamically import utilities
-        try {
-            const math = require('@orion-ecs/math');
-            Vector2Class = math.Vector2;
-        } catch {
-            console.warn('[InputManagerPlugin] Could not load math package');
-        }
-
         // Create a system to clear frame state at end of frame
         context.createSystem(
             'InputFrameCleanupSystem',


### PR DESCRIPTION
- Transform component: Remove position getter and setPosition method to follow the ECS data-only principle. Components should be pure data containers without methods.

- InputManagerPlugin: Replace dynamic require with static import for Vector2. Since @orion-ecs/math is a peer dependency, we can import it directly - no need to store the class reference.

Tests updated to verify direct property access pattern for Transform.