### PR TITLE
feat: Check custom ESLint rule for component types

### DIFF
--- a/packages/eslint-plugin-ecs/src/__tests__/component-types.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/component-types.test.ts
@@ -1,0 +1,264 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import * as path from 'path';
+import { componentTypes } from '../rules/component-types';
+
+// Configure RuleTester with TypeScript parser for type-aware rules
+// Use projectService for better handling of virtual test files
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            projectService: {
+                allowDefaultProject: ['*.ts'],
+                defaultProject: path.join(__dirname, '../../tsconfig.test.json'),
+            },
+            tsconfigRootDir: path.join(__dirname, '../..'),
+        },
+    },
+});
+
+ruleTester.run('component-types', componentTypes, {
+    valid: [
+        // Data-only component class
+        {
+            code: `
+        class Position {
+          x: number = 0;
+          y: number = 0;
+          constructor(x: number = 0, y: number = 0) {
+            this.x = x;
+            this.y = y;
+          }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Position, 0, 0);
+      `,
+        },
+        // Component with allowed methods (clone, reset, toString)
+        {
+            code: `
+        class Velocity {
+          x: number = 0;
+          y: number = 0;
+          constructor(x: number = 0, y: number = 0) {
+            this.x = x;
+            this.y = y;
+          }
+          clone() { return new Velocity(this.x, this.y); }
+          reset() { this.x = 0; this.y = 0; }
+          toString() { return \`(\${this.x}, \${this.y})\`; }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Velocity, 1, 1);
+      `,
+        },
+        // Using component in createSystem query
+        {
+            code: `
+        class Position {
+          x: number = 0;
+          y: number = 0;
+        }
+        class Velocity {
+          x: number = 0;
+          y: number = 0;
+        }
+
+        declare const engine: { createSystem: (name: string, query: any, options: any) => void };
+        engine.createSystem('Movement', {
+          all: [Position, Velocity]
+        }, {
+          act: () => {}
+        });
+      `,
+        },
+        // Component with private methods (prefixed with _) - allowed
+        {
+            code: `
+        class Health {
+          current: number = 100;
+          max: number = 100;
+          private _validate() { return this.current >= 0; }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Health);
+      `,
+        },
+        // Excluded pattern
+        {
+            code: `
+        class ServiceWithMethods {
+          doSomething() { return 'result'; }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(ServiceWithMethods);
+      `,
+            options: [{ excludePatterns: ['Service'] }],
+        },
+    ],
+    invalid: [
+        // Component with method
+        {
+            code: `
+        class Position {
+          x: number = 0;
+          y: number = 0;
+          distanceTo(other: Position): number {
+            return Math.sqrt((this.x - other.x) ** 2 + (this.y - other.y) ** 2);
+          }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Position, 0, 0);
+      `,
+            errors: [{ messageId: 'componentHasMethods' }],
+        },
+        // Component with getter
+        {
+            code: `
+        class Health {
+          current: number = 100;
+          max: number = 100;
+          get percentage(): number {
+            return this.current / this.max;
+          }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Health);
+      `,
+            errors: [{ messageId: 'componentHasGettersSetters' }],
+        },
+        // Component with setter
+        {
+            code: `
+        class Transform {
+          x: number = 0;
+          y: number = 0;
+          set position(value: { x: number; y: number }) {
+            this.x = value.x;
+            this.y = value.y;
+          }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Transform);
+      `,
+            errors: [{ messageId: 'componentHasGettersSetters' }],
+        },
+        // Component with arrow function property
+        {
+            code: `
+        class Velocity {
+          x: number = 0;
+          y: number = 0;
+          normalize = () => {
+            const len = Math.sqrt(this.x * this.x + this.y * this.y);
+            this.x /= len;
+            this.y /= len;
+          };
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(Velocity);
+      `,
+            errors: [{ messageId: 'componentHasMethods' }],
+        },
+        // Method in createSystem query
+        {
+            code: `
+        class Position {
+          x: number = 0;
+          y: number = 0;
+          update() { /* logic */ }
+        }
+        class Velocity {
+          x: number = 0;
+          y: number = 0;
+        }
+
+        declare const engine: { createSystem: (name: string, query: any, options: any) => void };
+        engine.createSystem('Movement', {
+          all: [Position, Velocity]
+        }, {
+          act: () => {}
+        });
+      `,
+            errors: [{ messageId: 'componentHasMethods' }],
+        },
+        // Multiple methods
+        {
+            code: `
+        class ComplexComponent {
+          data: number = 0;
+          process() { return this.data * 2; }
+          transform(factor: number) { this.data *= factor; }
+          validate() { return this.data >= 0; }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(ComplexComponent);
+      `,
+            errors: [{ messageId: 'componentHasMethods' }],
+        },
+        // Both methods and getters
+        {
+            code: `
+        class BadComponent {
+          value: number = 0;
+          get doubled(): number { return this.value * 2; }
+          compute() { return this.value * 3; }
+        }
+
+        declare const entity: { addComponent: <T>(type: new (...args: any[]) => T, ...args: any[]) => T };
+        entity.addComponent(BadComponent);
+      `,
+            errors: [
+                { messageId: 'componentHasMethods' },
+                { messageId: 'componentHasGettersSetters' },
+            ],
+        },
+        // Using getComponent with bad type
+        {
+            code: `
+        class HasMethod {
+          x: number = 0;
+          doThing() { return this.x; }
+        }
+
+        declare const entity: { getComponent: <T>(type: new (...args: any[]) => T) => T | undefined };
+        entity.getComponent(HasMethod);
+      `,
+            errors: [{ messageId: 'componentHasMethods' }],
+        },
+        // Using hasComponent with bad type
+        {
+            code: `
+        class HasGetter {
+          x: number = 0;
+          get y(): number { return this.x * 2; }
+        }
+
+        declare const entity: { hasComponent: <T>(type: new (...args: any[]) => T) => boolean };
+        entity.hasComponent(HasGetter);
+      `,
+            errors: [{ messageId: 'componentHasGettersSetters' }],
+        },
+        // Fluent query builder withAll
+        {
+            code: `
+        class BadComponent {
+          x: number = 0;
+          method() {}
+        }
+
+        declare const query: { withAll: (...types: any[]) => any };
+        query.withAll(BadComponent);
+      `,
+            errors: [{ messageId: 'componentHasMethods' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/index.ts
+++ b/packages/eslint-plugin-ecs/src/index.ts
@@ -1,4 +1,5 @@
 import { componentOrder } from './rules/component-order';
+import { componentTypes } from './rules/component-types';
 import { componentValidator } from './rules/component-validator';
 import { dataOnlyComponents } from './rules/data-only-components';
 import { noComponentLogic } from './rules/no-component-logic';
@@ -14,6 +15,7 @@ export const rules = {
     'no-entity-mutation-outside-system': noEntityMutationOutsideSystem,
     'component-validator': componentValidator,
     'component-order': componentOrder,
+    'component-types': componentTypes,
     'query-validator': queryValidator,
 };
 
@@ -25,6 +27,7 @@ const recommendedRules = {
     '@orion-ecs/ecs/no-entity-mutation-outside-system': 'off', // Off by default, can be noisy
     '@orion-ecs/ecs/component-validator': 'error', // Errors because these are likely bugs
     '@orion-ecs/ecs/component-order': 'warn', // Warn because may have false positives with dynamic code
+    '@orion-ecs/ecs/component-types': 'warn', // Requires type information, validates at call sites
     '@orion-ecs/ecs/query-validator': 'error', // Errors because these are logical contradictions
 } as const;
 
@@ -36,6 +39,7 @@ const strictRules = {
     '@orion-ecs/ecs/no-entity-mutation-outside-system': 'warn',
     '@orion-ecs/ecs/component-validator': 'error',
     '@orion-ecs/ecs/component-order': 'error',
+    '@orion-ecs/ecs/component-types': 'error', // Requires type information, validates at call sites
     '@orion-ecs/ecs/query-validator': 'error',
 } as const;
 

--- a/packages/eslint-plugin-ecs/src/rules/component-types.ts
+++ b/packages/eslint-plugin-ecs/src/rules/component-types.ts
@@ -1,0 +1,428 @@
+import {
+    ESLintUtils,
+    type ParserServicesWithTypeInformation,
+    type TSESTree,
+} from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+import { hasTypeInformation } from '../utils/component-registry';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds =
+    | 'componentHasMethods'
+    | 'componentHasGettersSetters'
+    | 'componentNotClass'
+    | 'componentHasComplexLogic';
+
+type Options = [
+    {
+        /**
+         * Methods allowed in component classes (e.g., 'clone', 'reset')
+         */
+        allowedMethods?: string[];
+        /**
+         * Whether to check for getters/setters
+         */
+        checkGettersSetters?: boolean;
+        /**
+         * Whether to check external/library components
+         */
+        checkExternalTypes?: boolean;
+        /**
+         * Patterns to exclude from checking (regex strings)
+         */
+        excludePatterns?: string[];
+    },
+];
+
+/**
+ * Information about a method found in a component class
+ */
+interface MethodInfo {
+    name: string;
+    kind: 'method' | 'getter' | 'setter';
+}
+
+/**
+ * Rule: component-types
+ *
+ * Validates that types passed to addComponent(), getComponent(), etc. are
+ * data-only classes. Uses TypeScript's type checker to resolve and inspect
+ * types, including those from external libraries.
+ *
+ * This catches cases where non-component classes are accidentally used as
+ * components, which would violate ECS best practices.
+ */
+export const componentTypes = createRule<Options, MessageIds>({
+    name: 'component-types',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Validate that component types used in ECS APIs are data-only classes',
+            requiresTypeChecking: true,
+        },
+        messages: {
+            componentHasMethods:
+                'Component "{{typeName}}" has methods that should be in a System: {{methods}}. Components should be data-only.',
+            componentHasGettersSetters:
+                'Component "{{typeName}}" has getters/setters: {{accessors}}. Use plain properties instead.',
+            componentNotClass:
+                'Type "{{typeName}}" is not a class. Components must be class types with a constructor.',
+            componentHasComplexLogic:
+                'Component "{{typeName}}" appears to have complex logic. Components should be simple data containers.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    allowedMethods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            'Method names that are allowed in components (e.g., "clone", "reset")',
+                    },
+                    checkGettersSetters: {
+                        type: 'boolean',
+                        description: 'Whether to check for getters/setters (default: true)',
+                    },
+                    checkExternalTypes: {
+                        type: 'boolean',
+                        description: 'Whether to check types from node_modules (default: true)',
+                    },
+                    excludePatterns: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Regex patterns for type names to exclude from checking',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            allowedMethods: ['clone', 'reset', 'toString', 'toJSON', 'valueOf'],
+            checkGettersSetters: true,
+            checkExternalTypes: true,
+            excludePatterns: [],
+        },
+    ],
+    create(context, [options]) {
+        const allowedMethods = new Set(options.allowedMethods ?? []);
+        const checkGettersSetters = options.checkGettersSetters ?? true;
+        const checkExternalTypes = options.checkExternalTypes ?? true;
+        const excludePatterns = (options.excludePatterns ?? []).map((p) => new RegExp(p));
+
+        // Check if type information is available
+        const parserServices = context.sourceCode.parserServices;
+        if (!hasTypeInformation(parserServices)) {
+            // Can't do type checking without type information
+            return {};
+        }
+
+        const typedServices = parserServices as ParserServicesWithTypeInformation;
+        const checker = typedServices.program.getTypeChecker();
+
+        /**
+         * Check if a type name should be excluded from checking
+         */
+        function isExcluded(typeName: string): boolean {
+            return excludePatterns.some((pattern) => pattern.test(typeName));
+        }
+
+        /**
+         * Check if a file path is in node_modules
+         */
+        function isExternalFile(fileName: string): boolean {
+            return fileName.includes('node_modules');
+        }
+
+        /**
+         * Get methods and accessors from a class type that violate data-only rule
+         */
+        function getViolatingMembers(type: ts.Type): {
+            methods: MethodInfo[];
+            accessors: MethodInfo[];
+        } {
+            const methods: MethodInfo[] = [];
+            const accessors: MethodInfo[] = [];
+
+            const symbol = type.getSymbol();
+            if (!symbol) {
+                return { methods, accessors };
+            }
+
+            // Get all members of the class
+            const members = symbol.members;
+            if (!members) {
+                return { methods, accessors };
+            }
+
+            members.forEach((memberSymbol, memberName) => {
+                const name = memberName.toString();
+
+                // Skip constructor
+                if (name === '__constructor' || name === 'constructor') {
+                    return;
+                }
+
+                // Skip allowed methods
+                if (allowedMethods.has(name)) {
+                    return;
+                }
+
+                // Skip private/internal members (convention: starts with _)
+                if (name.startsWith('_')) {
+                    return;
+                }
+
+                const declarations = memberSymbol.getDeclarations();
+                if (!declarations || declarations.length === 0) {
+                    return;
+                }
+
+                const declaration = declarations[0];
+
+                // Check for methods
+                if (ts.isMethodDeclaration(declaration)) {
+                    methods.push({ name, kind: 'method' });
+                    return;
+                }
+
+                // Check for getters/setters
+                if (ts.isGetAccessorDeclaration(declaration)) {
+                    accessors.push({ name, kind: 'getter' });
+                    return;
+                }
+
+                if (ts.isSetAccessorDeclaration(declaration)) {
+                    accessors.push({ name, kind: 'setter' });
+                    return;
+                }
+
+                // Check for arrow function properties
+                if (ts.isPropertyDeclaration(declaration)) {
+                    const initializer = declaration.initializer;
+                    if (
+                        initializer &&
+                        (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer))
+                    ) {
+                        methods.push({ name, kind: 'method' });
+                    }
+                }
+            });
+
+            return { methods, accessors };
+        }
+
+        /**
+         * Check if a type is a class type
+         */
+        function isClassType(type: ts.Type): boolean {
+            const symbol = type.getSymbol();
+            if (!symbol) {
+                return false;
+            }
+
+            const declarations = symbol.getDeclarations();
+            if (!declarations || declarations.length === 0) {
+                return false;
+            }
+
+            return declarations.some((d) => ts.isClassDeclaration(d) || ts.isClassExpression(d));
+        }
+
+        /**
+         * Get the type name for error messages
+         */
+        function getTypeName(type: ts.Type): string {
+            const symbol = type.getSymbol() ?? type.aliasSymbol;
+            if (symbol) {
+                return symbol.getName();
+            }
+            return checker.typeToString(type);
+        }
+
+        /**
+         * Get the declaration file for a type
+         */
+        function getDeclarationFile(type: ts.Type): string | undefined {
+            const symbol = type.getSymbol();
+            if (!symbol) {
+                return undefined;
+            }
+
+            const declarations = symbol.getDeclarations();
+            if (!declarations || declarations.length === 0) {
+                return undefined;
+            }
+
+            return declarations[0].getSourceFile().fileName;
+        }
+
+        /**
+         * Check a component type argument
+         */
+        function checkComponentType(node: TSESTree.Node, callNode: TSESTree.CallExpression): void {
+            try {
+                const tsNode = typedServices.esTreeNodeToTSNodeMap.get(node);
+                if (!tsNode) {
+                    return;
+                }
+
+                // Get the type of the node
+                const type = checker.getTypeAtLocation(tsNode);
+                if (!type) {
+                    return;
+                }
+
+                // For class references, we need to get the instance type
+                // The type of `Position` (the class itself) is `typeof Position`
+                // We need to get the construct signatures to find the instance type
+                let instanceType = type;
+
+                const constructSignatures = type.getConstructSignatures();
+                if (constructSignatures.length > 0) {
+                    // Get the return type of the construct signature (the instance type)
+                    instanceType = constructSignatures[0].getReturnType();
+                }
+
+                const typeName = getTypeName(instanceType);
+
+                // Check if excluded
+                if (isExcluded(typeName)) {
+                    return;
+                }
+
+                // Check if external and whether we should check external types
+                const declarationFile = getDeclarationFile(instanceType);
+                if (declarationFile && isExternalFile(declarationFile)) {
+                    if (!checkExternalTypes) {
+                        return;
+                    }
+                }
+
+                // Check if it's a class type
+                if (!isClassType(instanceType)) {
+                    // Only report if we have a meaningful type name
+                    if (typeName && typeName !== 'any' && typeName !== 'unknown') {
+                        context.report({
+                            node: callNode,
+                            messageId: 'componentNotClass',
+                            data: { typeName },
+                        });
+                    }
+                    return;
+                }
+
+                // Check for violating members
+                const { methods, accessors } = getViolatingMembers(instanceType);
+
+                if (methods.length > 0) {
+                    context.report({
+                        node: callNode,
+                        messageId: 'componentHasMethods',
+                        data: {
+                            typeName,
+                            methods: methods.map((m) => m.name).join(', '),
+                        },
+                    });
+                }
+
+                if (checkGettersSetters && accessors.length > 0) {
+                    context.report({
+                        node: callNode,
+                        messageId: 'componentHasGettersSetters',
+                        data: {
+                            typeName,
+                            accessors: accessors.map((a) => a.name).join(', '),
+                        },
+                    });
+                }
+            } catch {
+                // Type resolution can fail for various reasons, skip gracefully
+            }
+        }
+
+        /**
+         * Check if a call is a component API call and validate the type argument
+         */
+        function checkCallExpression(node: TSESTree.CallExpression): void {
+            const callee = node.callee;
+
+            // Must be a member expression (entity.addComponent, engine.createSystem, etc.)
+            if (callee.type !== 'MemberExpression') {
+                return;
+            }
+
+            if (callee.property.type !== 'Identifier') {
+                return;
+            }
+
+            const methodName = callee.property.name;
+
+            // Check single-component methods
+            if (
+                [
+                    'addComponent',
+                    'getComponent',
+                    'hasComponent',
+                    'removeComponent',
+                    'registerComponent',
+                    'registerComponentPool',
+                    'registerComponentValidator',
+                    'setSingleton',
+                    'getSingleton',
+                    'hasSingleton',
+                    'removeSingleton',
+                ].includes(methodName)
+            ) {
+                const componentArg = node.arguments[0];
+                if (componentArg) {
+                    checkComponentType(componentArg, node);
+                }
+                return;
+            }
+
+            // Check fluent query builder methods
+            if (['withAll', 'withAny', 'withNone'].includes(methodName)) {
+                for (const arg of node.arguments) {
+                    checkComponentType(arg, node);
+                }
+                return;
+            }
+
+            // Check createSystem and createQuery with query objects
+            if (methodName === 'createSystem' || methodName === 'createQuery') {
+                const queryArg =
+                    methodName === 'createSystem' ? node.arguments[1] : node.arguments[0];
+
+                if (queryArg && queryArg.type === 'ObjectExpression') {
+                    for (const prop of queryArg.properties) {
+                        if (prop.type !== 'Property') continue;
+                        if (prop.key.type !== 'Identifier') continue;
+
+                        const keyName = prop.key.name;
+                        if (['all', 'any', 'none', 'with', 'without'].includes(keyName)) {
+                            if (prop.value.type === 'ArrayExpression') {
+                                for (const element of prop.value.elements) {
+                                    if (element) {
+                                        checkComponentType(element, node);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return {
+            CallExpression: checkCallExpression,
+        };
+    },
+});
+
+export default componentTypes;

--- a/packages/eslint-plugin-ecs/tsconfig.test.json
+++ b/packages/eslint-plugin-ecs/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}


### PR DESCRIPTION
Add a new type-aware ESLint rule that validates component types at addComponent(), getComponent(), and other ECS API call sites. This catches cases where non-data-only classes are used as components, including types from external libraries.

- Uses TypeScript type checker to resolve and inspect types
- Detects methods, getters/setters, and arrow function properties
- Supports allowed methods list (clone, reset, toString, toJSON, valueOf)
- Supports exclude patterns for specific type names
- Works with createSystem queries and fluent query builder
- Configurable external type checking