### PR TITLE
feat: Create proposed custom ESLint rules for ECS framework

### DIFF
--- a/packages/eslint-plugin-ecs/src/__tests__/component-lifecycle-complete.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/component-lifecycle-complete.test.ts
@@ -1,0 +1,89 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { componentLifecycleComplete } from '../rules/component-lifecycle-complete';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('component-lifecycle-complete', componentLifecycleComplete, {
+    valid: [
+        // Both lifecycle methods present
+        {
+            code: `
+        class EventListenerComponent {
+          onCreate(entity) {
+            window.addEventListener('click', this.handleClick);
+          }
+          onDestroy(entity) {
+            window.removeEventListener('click', this.handleClick);
+          }
+        }
+      `,
+        },
+        // No lifecycle methods (just data)
+        {
+            code: `
+        class PositionComponent {
+          constructor(public x: number = 0, public y: number = 0) {}
+        }
+      `,
+        },
+        // Only onDestroy (less common but allowed)
+        {
+            code: `
+        class CleanupComponent {
+          onDestroy(entity) {
+            console.log('cleaned up');
+          }
+        }
+      `,
+        },
+        // Non-component class
+        {
+            code: `
+        class GameManager {
+          onCreate() {
+            // Not a component, should be ignored
+          }
+        }
+      `,
+        },
+        // Component with onChanged only
+        {
+            code: `
+        class HealthComponent {
+          onChanged() {
+            console.log('health changed');
+          }
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // onCreate without onDestroy
+        {
+            code: `
+        class ResourceComponent {
+          onCreate(entity) {
+            this.resource = loadResource();
+          }
+        }
+      `,
+            errors: [{ messageId: 'missingOnDestroy' }],
+        },
+        // Multiple components with missing onDestroy
+        {
+            code: `
+        class AudioComponent {
+          onCreate(entity) {
+            this.audio = new AudioContext();
+          }
+        }
+        class NetworkComponent {
+          onCreate(entity) {
+            this.socket = new WebSocket('ws://server');
+          }
+        }
+      `,
+            errors: [{ messageId: 'missingOnDestroy' }, { messageId: 'missingOnDestroy' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/no-async-in-system-callbacks.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/no-async-in-system-callbacks.test.ts
@@ -1,0 +1,172 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noAsyncInSystemCallbacks } from '../rules/no-async-in-system-callbacks';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-async-in-system-callbacks', noAsyncInSystemCallbacks, {
+    valid: [
+        // Synchronous act callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Movement', { all: [Position] }, {
+          act: (entity, pos) => {
+            pos.x += 1;
+          }
+        });
+      `,
+        },
+        // Synchronous before/after callbacks
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Render', { all: [Position] }, {
+          before: () => {
+            console.log('before');
+          },
+          act: (entity, pos) => {},
+          after: () => {
+            console.log('after');
+          }
+        });
+      `,
+        },
+        // Async function outside system
+        {
+            code: `
+        async function loadData() {
+          const data = await fetch('/api/data');
+          return data.json();
+        }
+      `,
+        },
+        // Async callback in non-system context
+        {
+            code: `
+        someObject.onEvent(async () => {
+          await doAsyncWork();
+        });
+      `,
+        },
+        // Promise-based work queued (non-blocking)
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Network', { all: [Position] }, {
+          act: (entity, pos) => {
+            // Queue async work without awaiting
+            loadData().then(data => {
+              engine.messageBus.publish('data-loaded', data, 'Network');
+            });
+          }
+        });
+      `,
+        },
+        // Function expression (non-async)
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Test', { all: [Position] }, {
+          act: function(entity, pos) {
+            pos.x += 1;
+          }
+        });
+      `,
+        },
+    ],
+    invalid: [
+        // Async arrow function in act
+        {
+            code: `
+        class Position {}
+        engine.createSystem('BadSystem', { all: [Position] }, {
+          act: async (entity, pos) => {
+            const data = await fetch('/api');
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'noAsyncSystemCallback' },
+                { messageId: 'noAwaitInSystemCallback' },
+            ],
+        },
+        // Async function expression in act
+        {
+            code: `
+        class Position {}
+        engine.createSystem('BadSystem', { all: [Position] }, {
+          act: async function(entity, pos) {
+            await doSomething();
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'noAsyncSystemCallback' },
+                { messageId: 'noAwaitInSystemCallback' },
+            ],
+        },
+        // Async before callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Setup', { all: [Position] }, {
+          before: async () => {
+            await loadResources();
+          },
+          act: (entity, pos) => {}
+        });
+      `,
+            errors: [
+                { messageId: 'noAsyncSystemCallback' },
+                { messageId: 'noAwaitInSystemCallback' },
+            ],
+        },
+        // Async after callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Cleanup', { all: [Position] }, {
+          act: (entity, pos) => {},
+          after: async () => {
+            await saveState();
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'noAsyncSystemCallback' },
+                { messageId: 'noAwaitInSystemCallback' },
+            ],
+        },
+        // Await in nested function inside act
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Nested', { all: [Position] }, {
+          act: (entity, pos) => {
+            async function innerAsync() {
+              await fetch('/api');
+            }
+            innerAsync();
+          }
+        });
+      `,
+            errors: [{ messageId: 'noAwaitInSystemCallback' }],
+        },
+        // Multiple async callbacks
+        {
+            code: `
+        class Position {}
+        engine.createSystem('AllAsync', { all: [Position] }, {
+          before: async () => {},
+          act: async (entity, pos) => {},
+          after: async () => {}
+        });
+      `,
+            errors: [
+                { messageId: 'noAsyncSystemCallback' },
+                { messageId: 'noAsyncSystemCallback' },
+                { messageId: 'noAsyncSystemCallback' },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/no-magic-tag-strings.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/no-magic-tag-strings.test.ts
@@ -1,0 +1,83 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noMagicTagStrings } from '../rules/no-magic-tag-strings';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-magic-tag-strings', noMagicTagStrings, {
+    valid: [
+        // Using constant/variable
+        {
+            code: `
+        const TAGS = { PLAYER: 'player', ENEMY: 'enemy' };
+        entity.addTag(TAGS.PLAYER);
+      `,
+        },
+        // Using imported constant
+        {
+            code: `
+        import { PLAYER_TAG } from './tags';
+        entity.addTag(PLAYER_TAG);
+      `,
+        },
+        // Allowed tag from options
+        {
+            code: `
+        entity.addTag('active');
+        entity.hasTag('active');
+      `,
+            options: [{ allowedTags: ['active'] }],
+        },
+        // Non-tag method with string (should be ignored)
+        {
+            code: `
+        entity.setName('player');
+        console.log('enemy');
+      `,
+        },
+    ],
+    invalid: [
+        // Magic string in addTag
+        {
+            code: `
+        entity.addTag('player');
+      `,
+            errors: [{ messageId: 'useMagicTagString' }],
+        },
+        // Magic string in removeTag
+        {
+            code: `
+        entity.removeTag('enemy');
+      `,
+            errors: [{ messageId: 'useMagicTagString' }],
+        },
+        // Magic string in hasTag
+        {
+            code: `
+        if (entity.hasTag('active')) {
+          // do something
+        }
+      `,
+            errors: [{ messageId: 'useMagicTagString' }],
+        },
+        // Magic string in getEntitiesByTag
+        {
+            code: `
+        const enemies = engine.getEntitiesByTag('enemy');
+      `,
+            errors: [{ messageId: 'useMagicTagString' }],
+        },
+        // Multiple magic strings
+        {
+            code: `
+        entity.addTag('player');
+        entity.addTag('controllable');
+        entity.addTag('active');
+      `,
+            errors: [
+                { messageId: 'useMagicTagString' },
+                { messageId: 'useMagicTagString' },
+                { messageId: 'useMagicTagString' },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/no-nested-transactions.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/no-nested-transactions.test.ts
@@ -1,0 +1,92 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noNestedTransactions } from '../rules/no-nested-transactions';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-nested-transactions', noNestedTransactions, {
+    valid: [
+        // Single transaction
+        {
+            code: `
+        engine.beginTransaction();
+        engine.createEntity();
+        engine.commitTransaction();
+      `,
+        },
+        // Sequential transactions
+        {
+            code: `
+        engine.beginTransaction();
+        engine.createEntity();
+        engine.commitTransaction();
+
+        engine.beginTransaction();
+        engine.createEntity();
+        engine.commitTransaction();
+      `,
+        },
+        // Transaction with rollback
+        {
+            code: `
+        engine.beginTransaction();
+        try {
+          engine.createEntity();
+          engine.commitTransaction();
+        } catch (e) {
+          engine.rollbackTransaction();
+        }
+      `,
+        },
+        // Transactions in different functions
+        {
+            code: `
+        function createBatch1() {
+          engine.beginTransaction();
+          engine.createEntity();
+          engine.commitTransaction();
+        }
+
+        function createBatch2() {
+          engine.beginTransaction();
+          engine.createEntity();
+          engine.commitTransaction();
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // Nested beginTransaction
+        {
+            code: `
+        engine.beginTransaction();
+        engine.beginTransaction();
+        engine.commitTransaction();
+        engine.commitTransaction();
+      `,
+            errors: [{ messageId: 'nestedTransaction' }],
+        },
+        // Multiple nested levels
+        {
+            code: `
+        engine.beginTransaction();
+        engine.beginTransaction();
+        engine.beginTransaction();
+        engine.commitTransaction();
+        engine.commitTransaction();
+        engine.commitTransaction();
+      `,
+            errors: [{ messageId: 'nestedTransaction' }, { messageId: 'nestedTransaction' }],
+        },
+        // Nested in conditional (still bad if reachable)
+        {
+            code: `
+        engine.beginTransaction();
+        if (condition) {
+          engine.beginTransaction();
+        }
+        engine.commitTransaction();
+      `,
+            errors: [{ messageId: 'nestedTransaction' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/no-query-in-act-callback.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/no-query-in-act-callback.test.ts
@@ -1,0 +1,160 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noQueryInActCallback } from '../rules/no-query-in-act-callback';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-query-in-act-callback', noQueryInActCallback, {
+    valid: [
+        // Query created outside system - correct pattern
+        {
+            code: `
+        class Position {}
+        class Velocity {}
+        const movementQuery = engine.createQuery({ all: [Position, Velocity] });
+        engine.createSystem('Movement', { all: [Position] }, {
+          act: (entity, pos) => {
+            for (const other of movementQuery.getEntities()) {
+              // do something
+            }
+          }
+        });
+      `,
+        },
+        // Query created in module scope
+        {
+            code: `
+        class Position {}
+        const query = engine.createQuery({ all: [Position] });
+        function process() {
+          for (const entity of query.getEntities()) {}
+        }
+      `,
+        },
+        // Regular method call inside act (not a query method)
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Movement', { all: [Position] }, {
+          act: (entity, pos) => {
+            entity.getComponent(Position);
+            console.log('processing');
+          }
+        });
+      `,
+        },
+        // Query in a non-system function
+        {
+            code: `
+        class Position {}
+        function findEntities() {
+          return engine.createQuery({ all: [Position] }).getEntities();
+        }
+      `,
+        },
+        // Query created before system in same scope
+        {
+            code: `
+        class Position {}
+        class Enemy {}
+        function setupGame() {
+          const enemyQuery = engine.createQuery({ all: [Enemy] });
+          engine.createSystem('Combat', { all: [Position] }, {
+            act: (entity, pos) => {
+              for (const enemy of enemyQuery.getEntities()) {}
+            }
+          });
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // Query created inside act callback
+        {
+            code: `
+        class Position {}
+        class Collider {}
+        engine.createSystem('Collision', { all: [Position] }, {
+          act: (entity, pos) => {
+            const others = engine.createQuery({ all: [Position, Collider] });
+            for (const other of others.getEntities()) {}
+          }
+        });
+      `,
+            errors: [{ messageId: 'noQueryInSystemCallback' }],
+        },
+        // Query created inside before callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Setup', { all: [Position] }, {
+          before: () => {
+            const query = engine.createQuery({ all: [Position] });
+          },
+          act: (entity, pos) => {}
+        });
+      `,
+            errors: [{ messageId: 'noQueryInSystemCallback' }],
+        },
+        // Query created inside after callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Cleanup', { all: [Position] }, {
+          act: (entity, pos) => {},
+          after: () => {
+            const query = engine.createQuery({ all: [Position] });
+          }
+        });
+      `,
+            errors: [{ messageId: 'noQueryInSystemCallback' }],
+        },
+        // Fluent query builder inside act
+        {
+            code: `
+        class Position {}
+        class Velocity {}
+        engine.createSystem('Movement', { all: [Position] }, {
+          act: (entity, pos) => {
+            const query = engine.query().withAll(Position, Velocity).build();
+          }
+        });
+      `,
+            errors: [{ messageId: 'noQueryInSystemCallback' }],
+        },
+        // Multiple queries inside callbacks
+        {
+            code: `
+        class Position {}
+        class Enemy {}
+        class Bullet {}
+        engine.createSystem('Combat', { all: [Position] }, {
+          before: () => {
+            const enemies = engine.createQuery({ all: [Enemy] });
+          },
+          act: (entity, pos) => {
+            const bullets = engine.createQuery({ all: [Bullet] });
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'noQueryInSystemCallback' },
+                { messageId: 'noQueryInSystemCallback' },
+            ],
+        },
+        // Query in nested function inside act
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Deep', { all: [Position] }, {
+          act: (entity, pos) => {
+            function findNearby() {
+              return engine.createQuery({ all: [Position] });
+            }
+            findNearby();
+          }
+        });
+      `,
+            errors: [{ messageId: 'noQueryInSystemCallback' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/plugin-logging-format.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/plugin-logging-format.test.ts
@@ -1,0 +1,98 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { pluginLoggingFormat } from '../rules/plugin-logging-format';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('plugin-logging-format', pluginLoggingFormat, {
+    valid: [
+        // Correct logging format
+        {
+            code: `
+        class PhysicsPlugin implements EnginePlugin {
+          install(context) {
+            console.log('[PhysicsPlugin] Installed successfully');
+          }
+          uninstall() {
+            console.log('[PhysicsPlugin] Uninstalled successfully');
+          }
+        }
+      `,
+        },
+        // Various log levels with correct format
+        {
+            code: `
+        class AudioPlugin implements EnginePlugin {
+          install(context) {
+            console.info('[AudioPlugin] Loading audio system');
+            console.warn('[AudioPlugin] Audio context not available');
+            console.error('[AudioPlugin] Failed to load sound');
+            console.debug('[AudioPlugin] Debug info');
+          }
+        }
+      `,
+        },
+        // Non-plugin class (should be ignored)
+        {
+            code: `
+        class GameManager {
+          start() {
+            console.log('Game started');
+          }
+        }
+      `,
+        },
+        // Template literal with prefix
+        {
+            code: `
+        class InputPlugin implements EnginePlugin {
+          install(context) {
+            console.log(\`[InputPlugin] Bound \${keys.length} keys\`);
+          }
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // Missing prefix
+        {
+            code: `
+        class PhysicsPlugin implements EnginePlugin {
+          install(context) {
+            console.log('Installed successfully');
+          }
+        }
+      `,
+            errors: [{ messageId: 'missingPluginPrefix' }],
+        },
+        // Wrong prefix
+        {
+            code: `
+        class AudioPlugin implements EnginePlugin {
+          install(context) {
+            console.log('[WrongName] Installed');
+          }
+        }
+      `,
+            errors: [{ messageId: 'incorrectLogFormat' }],
+        },
+        // Multiple logging issues
+        {
+            code: `
+        class NetworkPlugin implements EnginePlugin {
+          install(context) {
+            console.log('Starting network');
+            console.info('Connected');
+          }
+          uninstall() {
+            console.log('Disconnected');
+          }
+        }
+      `,
+            errors: [
+                { messageId: 'missingPluginPrefix' },
+                { messageId: 'missingPluginPrefix' },
+                { messageId: 'missingPluginPrefix' },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/plugin-structure-validation.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/plugin-structure-validation.test.ts
@@ -1,0 +1,144 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { pluginStructureValidation } from '../rules/plugin-structure-validation';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('plugin-structure-validation', pluginStructureValidation, {
+    valid: [
+        // Well-formed plugin
+        {
+            code: `
+        class PhysicsPlugin implements EnginePlugin {
+          readonly name = 'PhysicsPlugin';
+          readonly version = '1.0.0';
+
+          install(context: PluginContext): void {
+            // setup
+          }
+        }
+      `,
+        },
+        // Plugin with uninstall (optional)
+        {
+            code: `
+        class InputPlugin implements EnginePlugin {
+          readonly name = 'InputPlugin';
+          readonly version = '2.1.0';
+
+          install(context: PluginContext): void {}
+          uninstall(): void {}
+        }
+      `,
+        },
+        // Plugin with prerelease version
+        {
+            code: `
+        class BetaPlugin implements EnginePlugin {
+          readonly name = 'BetaPlugin';
+          readonly version = '1.0.0-beta.1';
+
+          install(context: PluginContext): void {}
+        }
+      `,
+        },
+        // Non-plugin class (should be ignored)
+        {
+            code: `
+        class GameManager {
+          name = 'manager';
+          start() {}
+        }
+      `,
+        },
+        // Plugin suffix not required
+        {
+            code: `
+        class NetworkExtension implements EnginePlugin {
+          readonly name = 'NetworkExtension';
+          readonly version = '1.0.0';
+          install(context: PluginContext): void {}
+        }
+      `,
+            options: [{ requirePluginSuffix: false, requireSemver: true }],
+        },
+    ],
+    invalid: [
+        // Missing name field
+        {
+            code: `
+        class MyPlugin implements EnginePlugin {
+          readonly version = '1.0.0';
+          install(context: PluginContext): void {}
+        }
+      `,
+            errors: [{ messageId: 'missingNameField' }],
+        },
+        // Missing version field
+        {
+            code: `
+        class MyPlugin implements EnginePlugin {
+          readonly name = 'MyPlugin';
+          install(context: PluginContext): void {}
+        }
+      `,
+            errors: [{ messageId: 'missingVersionField' }],
+        },
+        // Missing install method
+        {
+            code: `
+        class MyPlugin implements EnginePlugin {
+          readonly name = 'MyPlugin';
+          readonly version = '1.0.0';
+        }
+      `,
+            errors: [{ messageId: 'missingInstallMethod' }],
+        },
+        // Invalid version format
+        {
+            code: `
+        class MyPlugin implements EnginePlugin {
+          readonly name = 'MyPlugin';
+          readonly version = 'v1';
+          install(context: PluginContext): void {}
+        }
+      `,
+            errors: [{ messageId: 'invalidVersionFormat' }],
+        },
+        // Missing Plugin suffix
+        {
+            code: `
+        class NetworkManager implements EnginePlugin {
+          readonly name = 'NetworkManager';
+          readonly version = '1.0.0';
+          install(context: PluginContext): void {}
+        }
+      `,
+            errors: [{ messageId: 'pluginNamingConvention' }],
+        },
+        // Name field doesn't match class name
+        {
+            code: `
+        class AudioPlugin implements EnginePlugin {
+          readonly name = 'SoundPlugin';
+          readonly version = '1.0.0';
+          install(context: PluginContext): void {}
+        }
+      `,
+            errors: [{ messageId: 'nameFieldMismatch' }],
+        },
+        // Multiple issues (errors ordered by node position in source)
+        {
+            code: `
+        class BadExtension implements EnginePlugin {
+          readonly name = 'WrongName';
+        }
+      `,
+            errors: [
+                { messageId: 'missingVersionField' },
+                { messageId: 'missingInstallMethod' },
+                { messageId: 'pluginNamingConvention' },
+                { messageId: 'nameFieldMismatch' },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/prefer-queueFree.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/prefer-queueFree.test.ts
@@ -1,0 +1,60 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { preferQueueFree } from '../rules/prefer-queueFree';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-queueFree', preferQueueFree, {
+    valid: [
+        // Using queueFree
+        {
+            code: `
+        entity.queueFree();
+      `,
+        },
+        // Non-entity destroy
+        {
+            code: `
+        audioContext.destroy();
+        window.remove();
+      `,
+        },
+        // destroy on non-entity object
+        {
+            code: `
+        this.component.destroy();
+        manager.destroy();
+      `,
+        },
+    ],
+    invalid: [
+        // entity.destroy()
+        {
+            code: `
+        entity.destroy();
+      `,
+            errors: [{ messageId: 'preferQueueFree' }],
+        },
+        // this.entity.destroy()
+        {
+            code: `
+        this.entity.destroy();
+      `,
+            errors: [{ messageId: 'preferQueueFree' }],
+        },
+        // e.destroy() (common shorthand)
+        {
+            code: `
+        const e = engine.createEntity();
+        e.destroy();
+      `,
+            errors: [{ messageId: 'preferQueueFree' }],
+        },
+        // ent.remove()
+        {
+            code: `
+        ent.remove();
+      `,
+            errors: [{ messageId: 'preferQueueFree' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/require-hasComponent-before-getComponent.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/require-hasComponent-before-getComponent.test.ts
@@ -1,0 +1,162 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { requireHasComponentBeforeGetComponent } from '../rules/require-hasComponent-before-getComponent';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-hasComponent-before-getComponent', requireHasComponentBeforeGetComponent, {
+    valid: [
+        // hasComponent check before getComponent
+        {
+            code: `
+        class Velocity {}
+        if (entity.hasComponent(Velocity)) {
+          const vel = entity.getComponent(Velocity);
+          vel.x += 1;
+        }
+      `,
+        },
+        // Component guaranteed by system query
+        {
+            code: `
+        class Position {}
+        class Velocity {}
+        engine.createSystem('Movement', { all: [Position, Velocity] }, {
+          act: (entity, pos, vel) => {
+            // Position and Velocity are guaranteed by query
+            const p = entity.getComponent(Position);
+            const v = entity.getComponent(Velocity);
+          }
+        });
+      `,
+        },
+        // Conditional expression with hasComponent
+        {
+            code: `
+        class Health {}
+        const health = entity.hasComponent(Health)
+          ? entity.getComponent(Health).current
+          : 0;
+      `,
+        },
+        // Logical AND with hasComponent
+        {
+            code: `
+        class Buff {}
+        if (entity.hasComponent(Buff) && entity.getComponent(Buff).active) {
+          applyBuff(entity);
+        }
+      `,
+        },
+        // getComponent on parameters (assumed valid context)
+        {
+            code: `
+        class Armor {}
+        function processArmored(entity: Entity) {
+          if (entity.hasComponent(Armor)) {
+            const armor = entity.getComponent(Armor);
+            return armor.value;
+          }
+          return 0;
+        }
+      `,
+        },
+        // Query-guaranteed component accessed in nested function
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Nested', { all: [Position] }, {
+          act: (entity, pos) => {
+            function doSomething() {
+              const p = entity.getComponent(Position);
+            }
+            doSomething();
+          }
+        });
+      `,
+        },
+        // Always-guaranteed component via options
+        {
+            code: `
+        class Transform {}
+        const t = entity.getComponent(Transform);
+      `,
+            options: [{ queryGuaranteedComponents: ['Transform'] }],
+        },
+    ],
+    invalid: [
+        // Direct getComponent without check
+        {
+            code: `
+        class Velocity {}
+        const vel = entity.getComponent(Velocity);
+        vel.x += 1;
+      `,
+            errors: [{ messageId: 'missingHasComponentCheck' }],
+        },
+        // getComponent in system for non-query component
+        {
+            code: `
+        class Position {}
+        class Velocity {}
+        class Acceleration {}
+        engine.createSystem('Movement', { all: [Position, Velocity] }, {
+          act: (entity, pos, vel) => {
+            // Acceleration is NOT in query
+            const accel = entity.getComponent(Acceleration);
+            vel.x += accel.x;
+          }
+        });
+      `,
+            errors: [{ messageId: 'missingHasComponentCheck' }],
+        },
+        // getComponent in function without check
+        {
+            code: `
+        class Health {}
+        function damage(entity: Entity, amount: number) {
+          const health = entity.getComponent(Health);
+          health.current -= amount;
+        }
+      `,
+            errors: [{ messageId: 'missingHasComponentCheck' }],
+        },
+        // Multiple getComponent calls without checks
+        {
+            code: `
+        class Health {}
+        class Shield {}
+        const health = entity.getComponent(Health);
+        const shield = entity.getComponent(Shield);
+      `,
+            errors: [
+                { messageId: 'missingHasComponentCheck' },
+                { messageId: 'missingHasComponentCheck' },
+            ],
+        },
+        // Check for wrong component
+        {
+            code: `
+        class Health {}
+        class Shield {}
+        if (entity.hasComponent(Health)) {
+          // Check was for Health, not Shield
+          const shield = entity.getComponent(Shield);
+        }
+      `,
+            errors: [{ messageId: 'missingHasComponentCheck' }],
+        },
+        // getComponent in else branch (component not guaranteed)
+        {
+            code: `
+        class Armor {}
+        if (!entity.hasComponent(Armor)) {
+          console.log('no armor');
+        } else {
+          // This is fine, but let's test the else-if case
+        }
+        const armor = entity.getComponent(Armor);
+      `,
+            errors: [{ messageId: 'missingHasComponentCheck' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/singleton-mark-dirty.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/singleton-mark-dirty.test.ts
@@ -1,0 +1,130 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { singletonMarkDirty } from '../rules/singleton-mark-dirty';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('singleton-mark-dirty', singletonMarkDirty, {
+    valid: [
+        // Singleton modified and marked dirty
+        {
+            code: `
+        class GameTime {}
+        const time = engine.getSingleton(GameTime);
+        time.elapsed += deltaTime;
+        engine.markSingletonDirty(GameTime);
+      `,
+        },
+        // Mark dirty before modification (still valid)
+        {
+            code: `
+        class GameSettings {}
+        const settings = engine.getSingleton(GameSettings);
+        engine.markSingletonDirty(GameSettings);
+        settings.volume = 0.5;
+      `,
+        },
+        // Multiple singletons, all marked dirty
+        {
+            code: `
+        class GameTime {}
+        class Score {}
+        const time = engine.getSingleton(GameTime);
+        const score = engine.getSingleton(Score);
+        time.elapsed += 1;
+        score.value += 100;
+        engine.markSingletonDirty(GameTime);
+        engine.markSingletonDirty(Score);
+      `,
+        },
+        // Singleton accessed but not modified
+        {
+            code: `
+        class GameState {}
+        const state = engine.getSingleton(GameState);
+        console.log(state.level);
+      `,
+        },
+        // Singleton used in condition only
+        {
+            code: `
+        class GameTime {}
+        const time = engine.getSingleton(GameTime);
+        if (time.elapsed > 10) {
+          console.log('10 seconds passed');
+        }
+      `,
+        },
+        // Modification in function with dirty mark
+        {
+            code: `
+        class Counter {}
+        function incrementCounter() {
+          const counter = engine.getSingleton(Counter);
+          counter.value += 1;
+          engine.markSingletonDirty(Counter);
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // Singleton modified without marking dirty
+        {
+            code: `
+        class GameTime {}
+        const time = engine.getSingleton(GameTime);
+        time.elapsed += deltaTime;
+      `,
+            errors: [{ messageId: 'missingSingletonDirtyMark' }],
+        },
+        // Multiple modifications without marking dirty
+        {
+            code: `
+        class GameSettings {}
+        const settings = engine.getSingleton(GameSettings);
+        settings.volume = 0.5;
+        settings.difficulty = 'hard';
+      `,
+            errors: [
+                { messageId: 'missingSingletonDirtyMark' },
+                { messageId: 'missingSingletonDirtyMark' },
+            ],
+        },
+        // Wrong singleton marked dirty
+        {
+            code: `
+        class GameTime {}
+        class Score {}
+        const time = engine.getSingleton(GameTime);
+        time.elapsed += 1;
+        engine.markSingletonDirty(Score);
+      `,
+            errors: [{ messageId: 'missingSingletonDirtyMark' }],
+        },
+        // One singleton marked, another not
+        {
+            code: `
+        class GameTime {}
+        class Score {}
+        const time = engine.getSingleton(GameTime);
+        const score = engine.getSingleton(Score);
+        time.elapsed += 1;
+        score.value += 100;
+        engine.markSingletonDirty(GameTime);
+      `,
+            errors: [{ messageId: 'missingSingletonDirtyMark' }],
+        },
+        // Modification in system without marking dirty
+        {
+            code: `
+        class GameTime {}
+        engine.createSystem('Timer', {}, {
+          act: () => {
+            const time = engine.getSingleton(GameTime);
+            time.elapsed += 0.016;
+          }
+        });
+      `,
+            errors: [{ messageId: 'missingSingletonDirtyMark' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/subscription-cleanup-required.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/subscription-cleanup-required.test.ts
@@ -1,0 +1,196 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { subscriptionCleanupRequired } from '../rules/subscription-cleanup-required';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('subscription-cleanup-required', subscriptionCleanupRequired, {
+    valid: [
+        // Properly stored and cleaned up subscription
+        {
+            code: `
+        class MyPlugin {
+          private unsubscribe?: () => void;
+
+          install(context: PluginContext): void {
+            this.unsubscribe = context.on('onComponentAdded', () => {});
+          }
+
+          uninstall(): void {
+            this.unsubscribe?.();
+          }
+        }
+      `,
+        },
+        // Multiple subscriptions properly handled
+        {
+            code: `
+        class PhysicsPlugin {
+          private sub1?: () => void;
+          private sub2?: () => void;
+
+          install(context: PluginContext): void {
+            this.sub1 = context.on('onStart', () => {});
+            this.sub2 = context.messageBus.subscribe('collision', () => {});
+          }
+
+          uninstall(): void {
+            this.sub1?.();
+            this.sub2?.();
+          }
+        }
+      `,
+        },
+        // Non-plugin class with subscriptions (should not be checked)
+        {
+            code: `
+        class GameManager {
+          install(): void {
+            engine.on('onStart', () => {});
+          }
+        }
+      `,
+        },
+        // Plugin without subscriptions
+        {
+            code: `
+        class SimplePlugin {
+          install(context: PluginContext): void {
+            context.registerComponent(Position);
+          }
+        }
+      `,
+        },
+        // Subscription stored and cleaned via unsubscribe method
+        {
+            code: `
+        class EventPlugin {
+          private subscription?: { unsubscribe: () => void };
+
+          install(context: PluginContext): void {
+            this.subscription = context.on('onUpdate', () => {});
+          }
+
+          uninstall(): void {
+            this.subscription?.unsubscribe();
+          }
+        }
+      `,
+        },
+        // Plugin class identified by implements clause
+        {
+            code: `
+        class MyExtension implements EnginePlugin {
+          private cleanup?: () => void;
+
+          install(context: PluginContext): void {
+            this.cleanup = context.on('onStop', () => {});
+          }
+
+          uninstall(): void {
+            this.cleanup?.();
+          }
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // Subscription not stored
+        {
+            code: `
+        class LeakyPlugin {
+          install(context: PluginContext): void {
+            context.on('onComponentAdded', () => {});
+          }
+
+          uninstall(): void {}
+        }
+      `,
+            errors: [{ messageId: 'subscriptionNotStored' }],
+        },
+        // Subscription stored but not cleaned up
+        {
+            code: `
+        class ForgetfulPlugin {
+          private unsubscribe?: () => void;
+
+          install(context: PluginContext): void {
+            this.unsubscribe = context.on('onStart', () => {});
+          }
+
+          uninstall(): void {
+            // Forgot to call this.unsubscribe
+            console.log('uninstalled');
+          }
+        }
+      `,
+            errors: [{ messageId: 'subscriptionNotCleanedUp' }],
+        },
+        // Plugin with subscriptions but no uninstall method
+        {
+            code: `
+        class IncompletePlugin {
+          private sub?: () => void;
+
+          install(context: PluginContext): void {
+            this.sub = context.on('onUpdate', () => {});
+          }
+        }
+      `,
+            errors: [{ messageId: 'missingUninstallMethod' }],
+        },
+        // Multiple subscriptions, one not cleaned
+        {
+            code: `
+        class PartialPlugin {
+          private sub1?: () => void;
+          private sub2?: () => void;
+
+          install(context: PluginContext): void {
+            this.sub1 = context.on('onStart', () => {});
+            this.sub2 = context.on('onStop', () => {});
+          }
+
+          uninstall(): void {
+            this.sub1?.();
+            // Forgot sub2
+          }
+        }
+      `,
+            errors: [{ messageId: 'subscriptionNotCleanedUp' }],
+        },
+        // MessageBus subscription not stored
+        {
+            code: `
+        class MessagePlugin {
+          install(context: PluginContext): void {
+            context.messageBus.subscribe('player-died', () => {});
+          }
+
+          uninstall(): void {}
+        }
+      `,
+            errors: [{ messageId: 'subscriptionNotStored' }],
+        },
+        // Multiple issues
+        {
+            code: `
+        class BadPlugin {
+          private storedSub?: () => void;
+
+          install(context: PluginContext): void {
+            context.on('onStart', () => {});
+            this.storedSub = context.on('onStop', () => {});
+          }
+
+          uninstall(): void {
+            // Neither subscription is cleaned up
+          }
+        }
+      `,
+            errors: [
+                { messageId: 'subscriptionNotStored' },
+                { messageId: 'subscriptionNotCleanedUp' },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/system-naming-convention.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/system-naming-convention.test.ts
@@ -1,0 +1,84 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { systemNamingConvention } from '../rules/system-naming-convention';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('system-naming-convention', systemNamingConvention, {
+    valid: [
+        // Correct naming with System suffix
+        {
+            code: `
+        class Position {}
+        engine.createSystem('MovementSystem', { all: [Position] }, {
+          priority: 100,
+          act: (entity, pos) => {}
+        });
+      `,
+        },
+        // Multiple correctly named systems
+        {
+            code: `
+        engine.createSystem('RenderSystem', {}, { act: () => {} });
+        engine.createSystem('PhysicsSystem', {}, { act: () => {} });
+        engine.createSystem('InputSystem', {}, { act: () => {} });
+      `,
+        },
+        // Custom suffix via options
+        {
+            code: `
+        engine.createSystem('MovementProcessor', {}, { act: () => {} });
+      `,
+            options: [{ requiredSuffix: 'Processor', requirePascalCase: true }],
+        },
+        // No suffix requirement
+        {
+            code: `
+        engine.createSystem('Movement', {}, { act: () => {} });
+      `,
+            options: [{ requiredSuffix: '', requirePascalCase: true }],
+        },
+    ],
+    invalid: [
+        // Missing System suffix
+        {
+            code: `
+        engine.createSystem('Movement', {}, { act: () => {} });
+      `,
+            errors: [{ messageId: 'systemNamingSuffix' }],
+        },
+        // lowercase name
+        {
+            code: `
+        engine.createSystem('movementSystem', {}, { act: () => {} });
+      `,
+            errors: [{ messageId: 'systemNamingCase' }],
+        },
+        // All lowercase
+        {
+            code: `
+        engine.createSystem('movement', {}, { act: () => {} });
+      `,
+            errors: [{ messageId: 'systemNamingSuffix' }, { messageId: 'systemNamingCase' }],
+        },
+        // snake_case
+        {
+            code: `
+        engine.createSystem('movement_system', {}, { act: () => {} });
+      `,
+            errors: [{ messageId: 'systemNamingSuffix' }, { messageId: 'systemNamingCase' }],
+        },
+        // Multiple violations
+        {
+            code: `
+        engine.createSystem('render', {}, { act: () => {} });
+        engine.createSystem('physics', {}, { act: () => {} });
+      `,
+            errors: [
+                { messageId: 'systemNamingSuffix' },
+                { messageId: 'systemNamingCase' },
+                { messageId: 'systemNamingSuffix' },
+                { messageId: 'systemNamingCase' },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/system-priority-explicit.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/system-priority-explicit.test.ts
@@ -1,0 +1,81 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { systemPriorityExplicit } from '../rules/system-priority-explicit';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('system-priority-explicit', systemPriorityExplicit, {
+    valid: [
+        // Explicit priority
+        {
+            code: `
+        class Position {}
+        engine.createSystem('MovementSystem', { all: [Position] }, {
+          priority: 100,
+          act: (entity, pos) => {}
+        });
+      `,
+        },
+        // Priority of 0 (still explicit)
+        {
+            code: `
+        class Position {}
+        engine.createSystem('DefaultSystem', { all: [Position] }, {
+          priority: 0,
+          act: (entity, pos) => {}
+        });
+      `,
+        },
+        // Negative priority
+        {
+            code: `
+        class Position {}
+        engine.createSystem('LastSystem', { all: [Position] }, {
+          priority: -100,
+          act: (entity, pos) => {}
+        });
+      `,
+        },
+        // Non-createSystem call (should be ignored)
+        {
+            code: `
+        someObject.createSystem('Test', {}, {
+          act: () => {}
+        });
+      `,
+        },
+    ],
+    invalid: [
+        // Missing priority in options
+        {
+            code: `
+        class Position {}
+        engine.createSystem('MovementSystem', { all: [Position] }, {
+          act: (entity, pos) => {}
+        });
+      `,
+            errors: [{ messageId: 'missingPriority' }],
+        },
+        // Missing options object entirely
+        {
+            code: `
+        class Position {}
+        engine.createSystem('SimpleSystem', { all: [Position] });
+      `,
+            errors: [{ messageId: 'missingPriority' }],
+        },
+        // Multiple systems without priority
+        {
+            code: `
+        class Position {}
+        class Velocity {}
+        engine.createSystem('System1', { all: [Position] }, {
+          act: (entity, pos) => {}
+        });
+        engine.createSystem('System2', { all: [Velocity] }, {
+          act: (entity, vel) => {}
+        });
+      `,
+            errors: [{ messageId: 'missingPriority' }, { messageId: 'missingPriority' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/__tests__/use-command-buffer-in-system.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/use-command-buffer-in-system.test.ts
@@ -1,0 +1,210 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { useCommandBufferInSystem } from '../rules/use-command-buffer-in-system';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('use-command-buffer-in-system', useCommandBufferInSystem, {
+    valid: [
+        // Using command buffer for spawning - correct pattern
+        {
+            code: `
+        class Position {}
+        class Weapon {}
+        engine.createSystem('Spawner', { all: [Weapon] }, {
+          act: (entity, weapon) => {
+            if (weapon.shouldFire) {
+              engine.commands.spawn()
+                .named('Bullet')
+                .with(Position, 0, 0);
+            }
+          }
+        });
+      `,
+        },
+        // Using command buffer for entity modification
+        {
+            code: `
+        class Health {}
+        class Buff {}
+        engine.createSystem('BuffSystem', { all: [Health] }, {
+          act: (entity, health) => {
+            engine.commands.entity(entity)
+              .add(Buff, 1.5)
+              .addTag('buffed');
+          }
+        });
+      `,
+        },
+        // Using command buffer for despawn
+        {
+            code: `
+        class Health {}
+        engine.createSystem('DeathSystem', { all: [Health] }, {
+          act: (entity, health) => {
+            if (health.current <= 0) {
+              engine.commands.despawn(entity);
+            }
+          }
+        });
+      `,
+        },
+        // Entity creation outside of system callback
+        {
+            code: `
+        class Position {}
+        function setupGame() {
+          const player = engine.createEntity('Player');
+          player.addComponent(Position, 0, 0);
+        }
+      `,
+        },
+        // Component modification outside of system callback
+        {
+            code: `
+        class Health {}
+        function healPlayer(player) {
+          const health = player.getComponent(Health);
+          health.current = health.max;
+        }
+      `,
+        },
+        // Nested function outside system context
+        {
+            code: `
+        class Enemy {}
+        class Position {}
+        function spawnEnemies() {
+          for (let i = 0; i < 10; i++) {
+            const enemy = engine.createEntity('Enemy');
+            enemy.addComponent(Position, i * 10, 0);
+            enemy.addTag('enemy');
+          }
+        }
+      `,
+        },
+    ],
+    invalid: [
+        // Direct entity creation in act callback
+        {
+            code: `
+        class Weapon {}
+        class Position {}
+        engine.createSystem('Spawner', { all: [Weapon] }, {
+          act: (entity, weapon) => {
+            if (weapon.shouldFire) {
+              const bullet = engine.createEntity('Bullet');
+              bullet.addComponent(Position, 0, 0);
+            }
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'useCommandBufferForCreate' },
+                { messageId: 'useCommandBufferForMutation' },
+            ],
+        },
+        // createEntities in before callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Setup', { all: [Position] }, {
+          before: () => {
+            engine.createEntities(10);
+          },
+          act: (entity, pos) => {}
+        });
+      `,
+            errors: [{ messageId: 'useCommandBufferForCreate' }],
+        },
+        // createFromPrefab in act callback
+        {
+            code: `
+        class Spawner {}
+        engine.createSystem('EnemySpawner', { all: [Spawner] }, {
+          act: (entity, spawner) => {
+            if (spawner.shouldSpawn) {
+              engine.createFromPrefab('Enemy', 'Enemy1');
+            }
+          }
+        });
+      `,
+            errors: [{ messageId: 'useCommandBufferForCreate' }],
+        },
+        // Direct component operations in act callback
+        {
+            code: `
+        class Health {}
+        class Buff {}
+        engine.createSystem('PowerUp', { all: [Health] }, {
+          act: (entity, health) => {
+            entity.addComponent(Buff, 1.5);
+            entity.addTag('powered');
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'useCommandBufferForMutation' },
+                { messageId: 'useCommandBufferForMutation' },
+            ],
+        },
+        // Direct queueFree in act callback
+        {
+            code: `
+        class Health {}
+        engine.createSystem('Death', { all: [Health] }, {
+          act: (entity, health) => {
+            if (health.current <= 0) {
+              entity.queueFree();
+            }
+          }
+        });
+      `,
+            errors: [{ messageId: 'useCommandBufferForMutation' }],
+        },
+        // Component removal in act callback
+        {
+            code: `
+        class Debuff {}
+        class Timer {}
+        engine.createSystem('DebuffExpiry', { all: [Debuff, Timer] }, {
+          act: (entity, debuff, timer) => {
+            if (timer.elapsed > debuff.duration) {
+              entity.removeComponent(Debuff);
+            }
+          }
+        });
+      `,
+            errors: [{ messageId: 'useCommandBufferForMutation' }],
+        },
+        // Hierarchy operations in act callback
+        {
+            code: `
+        class Parent {}
+        class Child {}
+        engine.createSystem('Hierarchy', { all: [Parent] }, {
+          act: (entity, parent) => {
+            const child = engine.createEntity('Child');
+            entity.addChild(child);
+          }
+        });
+      `,
+            errors: [
+                { messageId: 'useCommandBufferForCreate' },
+                { messageId: 'useCommandBufferForMutation' },
+            ],
+        },
+        // Operations in after callback
+        {
+            code: `
+        class Position {}
+        engine.createSystem('Cleanup', { all: [Position] }, {
+          act: (entity, pos) => {},
+          after: () => {
+            const marker = engine.createEntity('Marker');
+          }
+        });
+      `,
+            errors: [{ messageId: 'useCommandBufferForCreate' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/index.ts
+++ b/packages/eslint-plugin-ecs/src/index.ts
@@ -1,13 +1,33 @@
+// Existing rules
+
+import { componentLifecycleComplete } from './rules/component-lifecycle-complete';
 import { componentOrder } from './rules/component-order';
 import { componentValidator } from './rules/component-validator';
 import { dataOnlyComponents } from './rules/data-only-components';
+import { noAsyncInSystemCallbacks } from './rules/no-async-in-system-callbacks';
 import { noComponentLogic } from './rules/no-component-logic';
 import { noEntityMutationOutsideSystem } from './rules/no-entity-mutation-outside-system';
+import { noMagicTagStrings } from './rules/no-magic-tag-strings';
+import { noNestedTransactions } from './rules/no-nested-transactions';
+// Phase 1: Critical Safety Rules
+import { noQueryInActCallback } from './rules/no-query-in-act-callback';
+import { pluginLoggingFormat } from './rules/plugin-logging-format';
+// Phase 3: Best Practice Rules
+import { pluginStructureValidation } from './rules/plugin-structure-validation';
 import { preferComposition } from './rules/prefer-composition';
+import { preferQueueFree } from './rules/prefer-queueFree';
 import { queryValidator } from './rules/query-validator';
+// Phase 2: Correctness Rules
+import { requireHasComponentBeforeGetComponent } from './rules/require-hasComponent-before-getComponent';
+import { singletonMarkDirty } from './rules/singleton-mark-dirty';
+import { subscriptionCleanupRequired } from './rules/subscription-cleanup-required';
+import { systemNamingConvention } from './rules/system-naming-convention';
+import { systemPriorityExplicit } from './rules/system-priority-explicit';
+import { useCommandBufferInSystem } from './rules/use-command-buffer-in-system';
 
 // Export individual rules for direct access
 export const rules = {
+    // Original rules
     'data-only-components': dataOnlyComponents,
     'no-component-logic': noComponentLogic,
     'prefer-composition': preferComposition,
@@ -15,10 +35,31 @@ export const rules = {
     'component-validator': componentValidator,
     'component-order': componentOrder,
     'query-validator': queryValidator,
+
+    // Phase 1: Critical Safety Rules
+    'no-query-in-act-callback': noQueryInActCallback,
+    'use-command-buffer-in-system': useCommandBufferInSystem,
+    'subscription-cleanup-required': subscriptionCleanupRequired,
+
+    // Phase 2: Correctness Rules
+    'require-hasComponent-before-getComponent': requireHasComponentBeforeGetComponent,
+    'singleton-mark-dirty': singletonMarkDirty,
+    'no-async-in-system-callbacks': noAsyncInSystemCallbacks,
+
+    // Phase 3: Best Practice Rules
+    'plugin-structure-validation': pluginStructureValidation,
+    'system-priority-explicit': systemPriorityExplicit,
+    'component-lifecycle-complete': componentLifecycleComplete,
+    'no-magic-tag-strings': noMagicTagStrings,
+    'prefer-queueFree': preferQueueFree,
+    'system-naming-convention': systemNamingConvention,
+    'plugin-logging-format': pluginLoggingFormat,
+    'no-nested-transactions': noNestedTransactions,
 };
 
-// Recommended configuration - warns on all rules
+// Recommended configuration - warns on most rules
 const recommendedRules = {
+    // Original rules
     '@orion-ecs/ecs/data-only-components': 'warn',
     '@orion-ecs/ecs/no-component-logic': 'warn',
     '@orion-ecs/ecs/prefer-composition': 'warn',
@@ -26,10 +67,31 @@ const recommendedRules = {
     '@orion-ecs/ecs/component-validator': 'error', // Errors because these are likely bugs
     '@orion-ecs/ecs/component-order': 'warn', // Warn because may have false positives with dynamic code
     '@orion-ecs/ecs/query-validator': 'error', // Errors because these are logical contradictions
+
+    // Phase 1: Critical Safety Rules
+    '@orion-ecs/ecs/no-query-in-act-callback': 'error', // Critical performance issue
+    '@orion-ecs/ecs/use-command-buffer-in-system': 'error', // Prevents iterator invalidation
+    '@orion-ecs/ecs/subscription-cleanup-required': 'error', // Prevents memory leaks
+
+    // Phase 2: Correctness Rules
+    '@orion-ecs/ecs/require-hasComponent-before-getComponent': 'warn', // Prevents runtime errors
+    '@orion-ecs/ecs/singleton-mark-dirty': 'warn', // Ensures event propagation
+    '@orion-ecs/ecs/no-async-in-system-callbacks': 'warn', // Prevents hidden bugs
+
+    // Phase 3: Best Practice Rules
+    '@orion-ecs/ecs/plugin-structure-validation': 'error', // Enforces plugin architecture
+    '@orion-ecs/ecs/system-priority-explicit': 'off', // Off by default, can be noisy for simple projects
+    '@orion-ecs/ecs/component-lifecycle-complete': 'warn', // Encourages proper cleanup
+    '@orion-ecs/ecs/no-magic-tag-strings': 'off', // Off by default, can be noisy
+    '@orion-ecs/ecs/prefer-queueFree': 'warn', // Encourages safe deletion
+    '@orion-ecs/ecs/system-naming-convention': 'off', // Off by default, style preference
+    '@orion-ecs/ecs/plugin-logging-format': 'off', // Off by default, style preference
+    '@orion-ecs/ecs/no-nested-transactions': 'error', // Prevents runtime errors
 } as const;
 
-// Strict configuration - errors on core rules
+// Strict configuration - errors on most rules
 const strictRules = {
+    // Original rules
     '@orion-ecs/ecs/data-only-components': 'error',
     '@orion-ecs/ecs/no-component-logic': 'error',
     '@orion-ecs/ecs/prefer-composition': 'error',
@@ -37,6 +99,26 @@ const strictRules = {
     '@orion-ecs/ecs/component-validator': 'error',
     '@orion-ecs/ecs/component-order': 'error',
     '@orion-ecs/ecs/query-validator': 'error',
+
+    // Phase 1: Critical Safety Rules
+    '@orion-ecs/ecs/no-query-in-act-callback': 'error',
+    '@orion-ecs/ecs/use-command-buffer-in-system': 'error',
+    '@orion-ecs/ecs/subscription-cleanup-required': 'error',
+
+    // Phase 2: Correctness Rules
+    '@orion-ecs/ecs/require-hasComponent-before-getComponent': 'error',
+    '@orion-ecs/ecs/singleton-mark-dirty': 'error',
+    '@orion-ecs/ecs/no-async-in-system-callbacks': 'error',
+
+    // Phase 3: Best Practice Rules
+    '@orion-ecs/ecs/plugin-structure-validation': 'error',
+    '@orion-ecs/ecs/system-priority-explicit': 'warn',
+    '@orion-ecs/ecs/component-lifecycle-complete': 'error',
+    '@orion-ecs/ecs/no-magic-tag-strings': 'warn',
+    '@orion-ecs/ecs/prefer-queueFree': 'error',
+    '@orion-ecs/ecs/system-naming-convention': 'warn',
+    '@orion-ecs/ecs/plugin-logging-format': 'warn',
+    '@orion-ecs/ecs/no-nested-transactions': 'error',
 } as const;
 
 // Export configurations

--- a/packages/eslint-plugin-ecs/src/rules/component-lifecycle-complete.ts
+++ b/packages/eslint-plugin-ecs/src/rules/component-lifecycle-complete.ts
@@ -1,0 +1,157 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+import {
+    type ComponentDetectionResult,
+    createDetectionResult,
+    detectComponentsFromCall,
+} from '../utils/component-detection';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'missingOnDestroy' | 'missingOnCreate';
+
+type Options = [
+    {
+        /** Regex pattern to identify component classes */
+        componentPattern?: string;
+        /** Detect components from usage */
+        detectFromUsage?: boolean;
+    },
+];
+
+/**
+ * Find a method in a class
+ */
+function findMethod(node: TSESTree.ClassDeclaration, name: string): boolean {
+    for (const member of node.body.body) {
+        if (
+            member.type === 'MethodDefinition' &&
+            member.key.type === 'Identifier' &&
+            member.key.name === name
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Rule: component-lifecycle-complete
+ *
+ * Ensures that components with onCreate also have onDestroy,
+ * and vice versa. This helps prevent resource leaks where
+ * setup code in onCreate doesn't have corresponding cleanup.
+ */
+export const componentLifecycleComplete = createRule<Options, MessageIds>({
+    name: 'component-lifecycle-complete',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Require components with onCreate to also have onDestroy (and vice versa)',
+        },
+        messages: {
+            missingOnDestroy:
+                'Component "{{className}}" has onCreate but is missing onDestroy. Add onDestroy to clean up resources.',
+            missingOnCreate:
+                'Component "{{className}}" has onDestroy but is missing onCreate. Consider adding onCreate for symmetry.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    componentPattern: {
+                        type: 'string',
+                        description: 'Regex pattern to identify component classes',
+                    },
+                    detectFromUsage: {
+                        type: 'boolean',
+                        description: 'Detect components from usage patterns',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            componentPattern:
+                '(Component|Position|Velocity|Health|Transform|Sprite|Collider|State|Data)$',
+            detectFromUsage: false,
+        },
+    ],
+    create(context, [options]) {
+        const componentPattern = new RegExp(
+            options.componentPattern ||
+                '(Component|Position|Velocity|Health|Transform|Sprite|Collider|State|Data)$'
+        );
+        const detectFromUsage = options.detectFromUsage || false;
+
+        // For usage-based detection
+        const detectionResult: ComponentDetectionResult = createDetectionResult();
+        const classDeclarations = new Map<
+            string,
+            {
+                node: TSESTree.ClassDeclaration;
+                hasOnCreate: boolean;
+                hasOnDestroy: boolean;
+            }
+        >();
+
+        function isComponentClass(className: string): boolean {
+            const matchesPattern = componentPattern.test(className);
+            const detectedFromUsage =
+                detectFromUsage && detectionResult.componentClasses.has(className);
+            return matchesPattern || detectedFromUsage;
+        }
+
+        return {
+            ClassDeclaration(node) {
+                if (!node.id) return;
+
+                const className = node.id.name;
+                const hasOnCreate = findMethod(node, 'onCreate');
+                const hasOnDestroy = findMethod(node, 'onDestroy');
+
+                classDeclarations.set(className, {
+                    node,
+                    hasOnCreate,
+                    hasOnDestroy,
+                });
+            },
+
+            CallExpression(node) {
+                if (detectFromUsage) {
+                    detectComponentsFromCall(node, detectionResult);
+                }
+            },
+
+            'Program:exit'() {
+                for (const [className, info] of classDeclarations) {
+                    if (!isComponentClass(className)) continue;
+
+                    // Check for imbalanced lifecycle methods
+                    if (info.hasOnCreate && !info.hasOnDestroy) {
+                        context.report({
+                            node: info.node,
+                            messageId: 'missingOnDestroy',
+                            data: { className },
+                        });
+                    }
+
+                    // Note: missingOnCreate is less severe, just a suggestion
+                    // Uncomment if you want strict symmetry:
+                    // if (info.hasOnDestroy && !info.hasOnCreate) {
+                    //     context.report({
+                    //         node: info.node,
+                    //         messageId: 'missingOnCreate',
+                    //         data: { className },
+                    //     });
+                    // }
+                }
+            },
+        };
+    },
+});
+
+export default componentLifecycleComplete;

--- a/packages/eslint-plugin-ecs/src/rules/no-async-in-system-callbacks.ts
+++ b/packages/eslint-plugin-ecs/src/rules/no-async-in-system-callbacks.ts
@@ -1,0 +1,187 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'noAsyncSystemCallback' | 'noAwaitInSystemCallback';
+
+type Options = [
+    {
+        /** System callback names to check */
+        callbackNames?: string[];
+    },
+];
+
+/**
+ * Check if a function is inside a system callback
+ */
+function getSystemCallbackInfo(node: TSESTree.Node): {
+    isInside: boolean;
+    callbackName: string | null;
+} {
+    let current: TSESTree.Node | undefined = node;
+
+    while (current) {
+        if (current.type === 'ArrowFunctionExpression' || current.type === 'FunctionExpression') {
+            const parent = current.parent;
+
+            if (parent?.type === 'Property' && parent.key.type === 'Identifier') {
+                const propName = parent.key.name;
+
+                if (['act', 'before', 'after'].includes(propName)) {
+                    // Verify this is in a createSystem call
+                    let objParent: TSESTree.Node | undefined = parent.parent;
+
+                    while (objParent && objParent.type !== 'ObjectExpression') {
+                        objParent = objParent.parent;
+                    }
+
+                    if (objParent?.type === 'ObjectExpression') {
+                        const callExpr = objParent.parent;
+
+                        if (callExpr?.type === 'CallExpression') {
+                            const callee = callExpr.callee;
+                            if (
+                                callee.type === 'MemberExpression' &&
+                                callee.property.type === 'Identifier' &&
+                                callee.property.name === 'createSystem'
+                            ) {
+                                return { isInside: true, callbackName: propName };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        current = current.parent;
+    }
+
+    return { isInside: false, callbackName: null };
+}
+
+/**
+ * Check if a node is directly a system callback function
+ */
+function isSystemCallbackFunction(
+    node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression
+): { isCallback: boolean; callbackName: string | null } {
+    const parent = node.parent;
+
+    if (parent?.type === 'Property' && parent.key.type === 'Identifier') {
+        const propName = parent.key.name;
+
+        if (['act', 'before', 'after'].includes(propName)) {
+            // Verify this is in a createSystem call
+            let objParent: TSESTree.Node | undefined = parent.parent;
+
+            while (objParent && objParent.type !== 'ObjectExpression') {
+                objParent = objParent.parent;
+            }
+
+            if (objParent?.type === 'ObjectExpression') {
+                const callExpr = objParent.parent;
+
+                if (callExpr?.type === 'CallExpression') {
+                    const callee = callExpr.callee;
+                    if (
+                        callee.type === 'MemberExpression' &&
+                        callee.property.type === 'Identifier' &&
+                        callee.property.name === 'createSystem'
+                    ) {
+                        return { isCallback: true, callbackName: propName };
+                    }
+                }
+            }
+        }
+    }
+
+    return { isCallback: false, callbackName: null };
+}
+
+/**
+ * Rule: no-async-in-system-callbacks
+ *
+ * Prevents async functions and await expressions in system callbacks.
+ * System callbacks (act, before, after) run synchronously during the game loop.
+ * Async operations can cause frame timing issues and unexpected behavior.
+ */
+export const noAsyncInSystemCallbacks = createRule<Options, MessageIds>({
+    name: 'no-async-in-system-callbacks',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow async functions and await expressions in system callbacks',
+        },
+        messages: {
+            noAsyncSystemCallback:
+                'System callback "{{callbackName}}" should not be async. Async operations can cause frame timing issues. Use a message queue or command buffer for async work.',
+            noAwaitInSystemCallback:
+                'Avoid await expressions inside system callback "{{callbackName}}". Systems run synchronously during the game loop. Queue async work using events or a task system instead.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    callbackNames: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'System callback names to check',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            callbackNames: ['act', 'before', 'after'],
+        },
+    ],
+    create(context) {
+        return {
+            // Check for async arrow functions
+            ArrowFunctionExpression(node) {
+                if (!node.async) return;
+
+                const { isCallback, callbackName } = isSystemCallbackFunction(node);
+                if (isCallback && callbackName) {
+                    context.report({
+                        node,
+                        messageId: 'noAsyncSystemCallback',
+                        data: { callbackName },
+                    });
+                }
+            },
+
+            // Check for async function expressions
+            FunctionExpression(node) {
+                if (!node.async) return;
+
+                const { isCallback, callbackName } = isSystemCallbackFunction(node);
+                if (isCallback && callbackName) {
+                    context.report({
+                        node,
+                        messageId: 'noAsyncSystemCallback',
+                        data: { callbackName },
+                    });
+                }
+            },
+
+            // Check for await expressions inside system callbacks
+            AwaitExpression(node) {
+                const { isInside, callbackName } = getSystemCallbackInfo(node);
+                if (isInside && callbackName) {
+                    context.report({
+                        node,
+                        messageId: 'noAwaitInSystemCallback',
+                        data: { callbackName },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default noAsyncInSystemCallbacks;

--- a/packages/eslint-plugin-ecs/src/rules/no-magic-tag-strings.ts
+++ b/packages/eslint-plugin-ecs/src/rules/no-magic-tag-strings.ts
@@ -1,0 +1,97 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'useMagicTagString';
+
+type Options = [
+    {
+        /** Known tag constants to allow */
+        allowedTags?: string[];
+    },
+];
+
+/**
+ * Convert tag string to suggested constant name
+ */
+function toConstantName(tag: string): string {
+    return tag.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+}
+
+/**
+ * Rule: no-magic-tag-strings
+ *
+ * Discourages using string literals directly in tag methods.
+ * Instead, encourage defining tag constants for better maintainability.
+ */
+export const noMagicTagStrings = createRule<Options, MessageIds>({
+    name: 'no-magic-tag-strings',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Discourage magic string literals in tag methods, prefer constants',
+        },
+        messages: {
+            useMagicTagString:
+                'Avoid using magic string "{{tagValue}}" directly. Define a constant like `const TAGS = { {{suggestedName}}: \'{{tagValue}}\' }` instead.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    allowedTags: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Tag strings that are allowed as literals',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            allowedTags: [],
+        },
+    ],
+    create(context, [options]) {
+        const allowedTags = new Set(options.allowedTags || []);
+
+        // Methods that use tags
+        const tagMethods = new Set(['addTag', 'removeTag', 'hasTag', 'getEntitiesByTag']);
+
+        return {
+            CallExpression(node) {
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const methodName = node.callee.property.name;
+
+                if (!tagMethods.has(methodName)) return;
+
+                // Check each argument that's a string literal
+                for (const arg of node.arguments) {
+                    if (arg.type === 'Literal' && typeof arg.value === 'string') {
+                        const tagValue = arg.value;
+
+                        // Skip allowed tags
+                        if (allowedTags.has(tagValue)) continue;
+
+                        context.report({
+                            node: arg,
+                            messageId: 'useMagicTagString',
+                            data: {
+                                tagValue,
+                                suggestedName: toConstantName(tagValue),
+                            },
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+export default noMagicTagStrings;

--- a/packages/eslint-plugin-ecs/src/rules/no-nested-transactions.ts
+++ b/packages/eslint-plugin-ecs/src/rules/no-nested-transactions.ts
@@ -1,0 +1,118 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'nestedTransaction';
+
+type Options = [];
+
+/**
+ * Check if a call is beginTransaction
+ */
+function isBeginTransaction(node: TSESTree.CallExpression): boolean {
+    if (node.callee.type !== 'MemberExpression') return false;
+    if (node.callee.property.type !== 'Identifier') return false;
+    return node.callee.property.name === 'beginTransaction';
+}
+
+/**
+ * Check if a call is commitTransaction or rollbackTransaction
+ */
+function isEndTransaction(node: TSESTree.CallExpression): boolean {
+    if (node.callee.type !== 'MemberExpression') return false;
+    if (node.callee.property.type !== 'Identifier') return false;
+    const name = node.callee.property.name;
+    return name === 'commitTransaction' || name === 'rollbackTransaction';
+}
+
+/**
+ * Rule: no-nested-transactions
+ *
+ * Prevents nested beginTransaction calls which are an error.
+ * Transactions cannot be nested and will throw at runtime.
+ */
+export const noNestedTransactions = createRule<Options, MessageIds>({
+    name: 'no-nested-transactions',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Prevent nested transaction calls',
+        },
+        messages: {
+            nestedTransaction:
+                'Nested beginTransaction call detected. Transactions cannot be nested and will throw at runtime. Ensure you call commitTransaction or rollbackTransaction before starting a new transaction.',
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        // Track transaction state per function scope
+        const transactionStack: { inTransaction: boolean; node: TSESTree.Node | null }[] = [];
+
+        function enterScope(): void {
+            transactionStack.push({ inTransaction: false, node: null });
+        }
+
+        function exitScope(): void {
+            transactionStack.pop();
+        }
+
+        function getCurrentScope():
+            | { inTransaction: boolean; node: TSESTree.Node | null }
+            | undefined {
+            return transactionStack[transactionStack.length - 1];
+        }
+
+        return {
+            // Track function scopes
+            Program() {
+                enterScope();
+            },
+            'Program:exit'() {
+                exitScope();
+            },
+            FunctionDeclaration() {
+                enterScope();
+            },
+            'FunctionDeclaration:exit'() {
+                exitScope();
+            },
+            FunctionExpression() {
+                enterScope();
+            },
+            'FunctionExpression:exit'() {
+                exitScope();
+            },
+            ArrowFunctionExpression() {
+                enterScope();
+            },
+            'ArrowFunctionExpression:exit'() {
+                exitScope();
+            },
+
+            CallExpression(node) {
+                const scope = getCurrentScope();
+                if (!scope) return;
+
+                if (isBeginTransaction(node)) {
+                    if (scope.inTransaction) {
+                        context.report({
+                            node,
+                            messageId: 'nestedTransaction',
+                        });
+                    } else {
+                        scope.inTransaction = true;
+                        scope.node = node;
+                    }
+                } else if (isEndTransaction(node)) {
+                    scope.inTransaction = false;
+                    scope.node = null;
+                }
+            },
+        };
+    },
+});
+
+export default noNestedTransactions;

--- a/packages/eslint-plugin-ecs/src/rules/no-query-in-act-callback.ts
+++ b/packages/eslint-plugin-ecs/src/rules/no-query-in-act-callback.ts
@@ -1,0 +1,149 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'noQueryInCallback' | 'noQueryInSystemCallback';
+
+type Options = [
+    {
+        /** Additional method names to treat as query-creating methods */
+        queryMethods?: string[];
+    },
+];
+
+/**
+ * Check if a node is inside a system callback (act, before, after)
+ */
+function isInsideSystemCallback(node: TSESTree.Node): {
+    isInside: boolean;
+    callbackType: string | null;
+} {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        // Check if we're in a function that's a property value
+        if (current.type === 'ArrowFunctionExpression' || current.type === 'FunctionExpression') {
+            const parent = current.parent;
+
+            // Check if this function is a property in an object
+            if (parent?.type === 'Property' && parent.key.type === 'Identifier') {
+                const propName = parent.key.name;
+
+                // Check for system callback property names
+                if (['act', 'before', 'after'].includes(propName)) {
+                    // Verify this is in a createSystem call by checking parent chain
+                    let objParent: TSESTree.Node | undefined = parent.parent;
+
+                    // Go up to find the ObjectExpression
+                    while (objParent && objParent.type !== 'ObjectExpression') {
+                        objParent = objParent.parent;
+                    }
+
+                    if (objParent?.type === 'ObjectExpression') {
+                        const callExpr = objParent.parent;
+
+                        // Check if this object is an argument to createSystem
+                        if (callExpr?.type === 'CallExpression') {
+                            const callee = callExpr.callee;
+                            if (
+                                callee.type === 'MemberExpression' &&
+                                callee.property.type === 'Identifier' &&
+                                callee.property.name === 'createSystem'
+                            ) {
+                                return { isInside: true, callbackType: propName };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        current = current.parent;
+    }
+
+    return { isInside: false, callbackType: null };
+}
+
+/**
+ * Rule: no-query-in-act-callback
+ *
+ * Prevents creating queries inside system callbacks (act, before, after).
+ * Queries created inside callbacks are recreated every frame, causing
+ * performance issues. Queries should be created once and cached.
+ */
+export const noQueryInActCallback = createRule<Options, MessageIds>({
+    name: 'no-query-in-act-callback',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow creating queries inside system callbacks (act, before, after)',
+        },
+        messages: {
+            noQueryInCallback:
+                'Avoid calling "{{methodName}}" inside system callbacks. Queries are recreated every frame. Create and cache the query outside the system instead.',
+            noQueryInSystemCallback:
+                'Query created inside "{{callbackType}}" callback will be recreated every frame. Move the query creation outside the system and cache it.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    queryMethods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Additional method names that create queries',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            queryMethods: [],
+        },
+    ],
+    create(context, [options]) {
+        // Methods that create queries
+        const queryMethods = new Set([
+            'createQuery',
+            'query', // Fluent query builder
+            ...(options.queryMethods || []),
+        ]);
+
+        return {
+            CallExpression(node) {
+                // Check if this is a query-creating method call
+                let methodName: string | null = null;
+
+                if (node.callee.type === 'MemberExpression') {
+                    if (node.callee.property.type === 'Identifier') {
+                        const propName = node.callee.property.name;
+                        if (queryMethods.has(propName)) {
+                            methodName = propName;
+                        }
+                    }
+                }
+
+                if (!methodName) return;
+
+                // Check if we're inside a system callback
+                const { isInside, callbackType } = isInsideSystemCallback(node);
+
+                if (isInside && callbackType) {
+                    context.report({
+                        node,
+                        messageId: 'noQueryInSystemCallback',
+                        data: {
+                            callbackType,
+                        },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default noQueryInActCallback;

--- a/packages/eslint-plugin-ecs/src/rules/plugin-logging-format.ts
+++ b/packages/eslint-plugin-ecs/src/rules/plugin-logging-format.ts
@@ -1,0 +1,165 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'missingPluginPrefix' | 'incorrectLogFormat';
+
+type Options = [
+    {
+        /** Expected log format pattern */
+        formatPattern?: string;
+    },
+];
+
+/**
+ * Check if we're inside a plugin class
+ */
+function findEnclosingPluginClass(node: TSESTree.Node): TSESTree.ClassDeclaration | null {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        if (current.type === 'ClassDeclaration') {
+            // Check if it's a plugin
+            if (current.id?.name.endsWith('Plugin')) {
+                return current;
+            }
+            if (current.implements) {
+                for (const impl of current.implements) {
+                    if (
+                        impl.expression.type === 'Identifier' &&
+                        impl.expression.name === 'EnginePlugin'
+                    ) {
+                        return current;
+                    }
+                }
+            }
+        }
+        current = current.parent;
+    }
+
+    return null;
+}
+
+/**
+ * Get the first string argument from a console.log call
+ */
+function getFirstStringArg(
+    node: TSESTree.CallExpression
+): { value: string; node: TSESTree.Node } | null {
+    const firstArg = node.arguments[0];
+
+    if (firstArg?.type === 'Literal' && typeof firstArg.value === 'string') {
+        return { value: firstArg.value, node: firstArg };
+    }
+
+    if (firstArg?.type === 'TemplateLiteral' && firstArg.quasis.length > 0) {
+        const value = firstArg.quasis[0].value.raw;
+        return { value, node: firstArg };
+    }
+
+    return null;
+}
+
+/**
+ * Rule: plugin-logging-format
+ *
+ * Enforces consistent logging format in plugins.
+ * Plugin logs should include the plugin name in brackets.
+ */
+export const pluginLoggingFormat = createRule<Options, MessageIds>({
+    name: 'plugin-logging-format',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Enforce consistent logging format in plugins',
+        },
+        messages: {
+            missingPluginPrefix:
+                'Plugin log message should include "[{{pluginName}}]" prefix for consistency.',
+            incorrectLogFormat:
+                'Plugin log format should be "[{{pluginName}}] message". Found: "{{actualFormat}}".',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    formatPattern: {
+                        type: 'string',
+                        description: 'Expected log format pattern',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            formatPattern: '\\[\\w+\\]',
+        },
+    ],
+    create(context) {
+        let currentPluginName: string | null = null;
+
+        return {
+            ClassDeclaration(node) {
+                if (node.id?.name.endsWith('Plugin')) {
+                    currentPluginName = node.id.name;
+                }
+            },
+
+            'ClassDeclaration:exit'(node: TSESTree.ClassDeclaration) {
+                if (node.id?.name === currentPluginName) {
+                    currentPluginName = null;
+                }
+            },
+
+            CallExpression(node) {
+                // Check for console.log calls
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.object.type !== 'Identifier') return;
+                if (node.callee.object.name !== 'console') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const method = node.callee.property.name;
+                if (!['log', 'info', 'warn', 'error', 'debug'].includes(method)) return;
+
+                // Only check within plugin classes
+                const pluginClass = findEnclosingPluginClass(node);
+                if (!pluginClass || !pluginClass.id) return;
+
+                const pluginName = pluginClass.id.name;
+                const expectedPrefix = `[${pluginName}]`;
+
+                const stringArg = getFirstStringArg(node);
+                if (!stringArg) return;
+
+                // Check if message starts with plugin prefix
+                if (!stringArg.value.startsWith(expectedPrefix)) {
+                    // Check if it has any bracket prefix
+                    const hasBracketPrefix = /^\[[\w]+\]/.test(stringArg.value);
+
+                    if (hasBracketPrefix) {
+                        context.report({
+                            node: stringArg.node,
+                            messageId: 'incorrectLogFormat',
+                            data: {
+                                pluginName,
+                                actualFormat: stringArg.value.substring(0, 30) + '...',
+                            },
+                        });
+                    } else {
+                        context.report({
+                            node: stringArg.node,
+                            messageId: 'missingPluginPrefix',
+                            data: { pluginName },
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+export default pluginLoggingFormat;

--- a/packages/eslint-plugin-ecs/src/rules/plugin-structure-validation.ts
+++ b/packages/eslint-plugin-ecs/src/rules/plugin-structure-validation.ts
@@ -1,0 +1,219 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds =
+    | 'missingNameField'
+    | 'missingVersionField'
+    | 'invalidVersionFormat'
+    | 'missingInstallMethod'
+    | 'pluginNamingConvention'
+    | 'nameFieldMismatch';
+
+type Options = [
+    {
+        /** Require plugin class names to end with 'Plugin' */
+        requirePluginSuffix?: boolean;
+        /** Require version to be valid semver */
+        requireSemver?: boolean;
+    },
+];
+
+/**
+ * Check if version string is valid semver
+ */
+function isValidSemver(version: string): boolean {
+    // Basic semver pattern: major.minor.patch with optional prerelease
+    const semverPattern = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
+    return semverPattern.test(version);
+}
+
+/**
+ * Check if a class implements EnginePlugin
+ */
+function isPluginClass(node: TSESTree.ClassDeclaration): boolean {
+    if (!node.implements) return false;
+
+    for (const impl of node.implements) {
+        if (impl.expression.type === 'Identifier') {
+            if (impl.expression.name === 'EnginePlugin') {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Find a property in a class
+ */
+function findClassProperty(
+    node: TSESTree.ClassDeclaration,
+    name: string
+): TSESTree.PropertyDefinition | null {
+    for (const member of node.body.body) {
+        if (
+            member.type === 'PropertyDefinition' &&
+            member.key.type === 'Identifier' &&
+            member.key.name === name
+        ) {
+            return member;
+        }
+    }
+    return null;
+}
+
+/**
+ * Find a method in a class
+ */
+function findClassMethod(
+    node: TSESTree.ClassDeclaration,
+    name: string
+): TSESTree.MethodDefinition | null {
+    for (const member of node.body.body) {
+        if (
+            member.type === 'MethodDefinition' &&
+            member.key.type === 'Identifier' &&
+            member.key.name === name
+        ) {
+            return member;
+        }
+    }
+    return null;
+}
+
+/**
+ * Get string value from a property
+ */
+function getStringValue(prop: TSESTree.PropertyDefinition): string | null {
+    if (prop.value?.type === 'Literal' && typeof prop.value.value === 'string') {
+        return prop.value.value;
+    }
+    return null;
+}
+
+/**
+ * Rule: plugin-structure-validation
+ *
+ * Validates that plugin classes follow the required structure:
+ * - Have a readonly name field
+ * - Have a readonly version field (optionally semver)
+ * - Have an install(context) method
+ * - Follow naming conventions (end with 'Plugin')
+ */
+export const pluginStructureValidation = createRule<Options, MessageIds>({
+    name: 'plugin-structure-validation',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Validate plugin class structure and required members',
+        },
+        messages: {
+            missingNameField: 'Plugin class "{{className}}" is missing a readonly "name" field.',
+            missingVersionField:
+                'Plugin class "{{className}}" is missing a readonly "version" field.',
+            invalidVersionFormat:
+                'Plugin version "{{version}}" is not valid semver format (e.g., "1.0.0").',
+            missingInstallMethod:
+                'Plugin class "{{className}}" is missing the required "install(context)" method.',
+            pluginNamingConvention: 'Plugin class "{{className}}" should end with "Plugin" suffix.',
+            nameFieldMismatch:
+                'Plugin name field "{{nameValue}}" does not match class name "{{className}}".',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    requirePluginSuffix: {
+                        type: 'boolean',
+                        description: 'Require plugin class names to end with Plugin',
+                    },
+                    requireSemver: {
+                        type: 'boolean',
+                        description: 'Require version to be valid semver',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            requirePluginSuffix: true,
+            requireSemver: true,
+        },
+    ],
+    create(context, [options]) {
+        return {
+            ClassDeclaration(node) {
+                if (!isPluginClass(node)) return;
+                if (!node.id) return;
+
+                const className = node.id.name;
+
+                // Check naming convention
+                if (options.requirePluginSuffix && !className.endsWith('Plugin')) {
+                    context.report({
+                        node: node.id,
+                        messageId: 'pluginNamingConvention',
+                        data: { className },
+                    });
+                }
+
+                // Check for name field
+                const nameProp = findClassProperty(node, 'name');
+                if (!nameProp) {
+                    context.report({
+                        node,
+                        messageId: 'missingNameField',
+                        data: { className },
+                    });
+                } else {
+                    // Check name matches class name
+                    const nameValue = getStringValue(nameProp);
+                    if (nameValue && nameValue !== className) {
+                        context.report({
+                            node: nameProp,
+                            messageId: 'nameFieldMismatch',
+                            data: { nameValue, className },
+                        });
+                    }
+                }
+
+                // Check for version field
+                const versionProp = findClassProperty(node, 'version');
+                if (!versionProp) {
+                    context.report({
+                        node,
+                        messageId: 'missingVersionField',
+                        data: { className },
+                    });
+                } else if (options.requireSemver) {
+                    const versionValue = getStringValue(versionProp);
+                    if (versionValue && !isValidSemver(versionValue)) {
+                        context.report({
+                            node: versionProp,
+                            messageId: 'invalidVersionFormat',
+                            data: { version: versionValue },
+                        });
+                    }
+                }
+
+                // Check for install method
+                const installMethod = findClassMethod(node, 'install');
+                if (!installMethod) {
+                    context.report({
+                        node,
+                        messageId: 'missingInstallMethod',
+                        data: { className },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default pluginStructureValidation;

--- a/packages/eslint-plugin-ecs/src/rules/prefer-queueFree.ts
+++ b/packages/eslint-plugin-ecs/src/rules/prefer-queueFree.ts
@@ -1,0 +1,92 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'preferQueueFree';
+
+type Options = [
+    {
+        /** Methods to suggest queueFree instead of */
+        unsafeMethods?: string[];
+    },
+];
+
+/**
+ * Rule: prefer-queueFree
+ *
+ * Suggests using entity.queueFree() for safe deferred entity deletion
+ * instead of potentially unsafe direct removal methods.
+ */
+export const preferQueueFree = createRule<Options, MessageIds>({
+    name: 'prefer-queueFree',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Prefer entity.queueFree() for safe deferred entity deletion',
+        },
+        messages: {
+            preferQueueFree:
+                'Prefer "entity.queueFree()" instead of "{{methodName}}" for safe deferred entity deletion. queueFree ensures proper cleanup after system iteration.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    unsafeMethods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Methods to suggest queueFree instead of',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            unsafeMethods: ['destroy', 'remove'],
+        },
+    ],
+    create(context, [options]) {
+        const unsafeMethods = new Set(['destroy', 'remove', ...(options.unsafeMethods || [])]);
+
+        return {
+            CallExpression(node) {
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const methodName = node.callee.property.name;
+
+                if (!unsafeMethods.has(methodName)) return;
+
+                // Check if this is likely an entity method call
+                // We look for patterns like entity.destroy() or this.entity.destroy()
+                const obj = node.callee.object;
+
+                let isLikelyEntity = false;
+
+                if (obj.type === 'Identifier') {
+                    const name = obj.name.toLowerCase();
+                    isLikelyEntity = name.includes('entity') || name === 'e' || name === 'ent';
+                }
+
+                if (obj.type === 'MemberExpression' && obj.property.type === 'Identifier') {
+                    const name = obj.property.name.toLowerCase();
+                    isLikelyEntity = name.includes('entity') || name === 'e';
+                }
+
+                if (isLikelyEntity) {
+                    context.report({
+                        node,
+                        messageId: 'preferQueueFree',
+                        data: { methodName },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default preferQueueFree;

--- a/packages/eslint-plugin-ecs/src/rules/require-hasComponent-before-getComponent.ts
+++ b/packages/eslint-plugin-ecs/src/rules/require-hasComponent-before-getComponent.ts
@@ -1,0 +1,241 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'missingHasComponentCheck';
+
+type Options = [
+    {
+        /** Component types guaranteed by system query (skip check for these) */
+        queryGuaranteedComponents?: string[];
+    },
+];
+
+/**
+ * Check if a getComponent call is preceded by hasComponent check for the same component
+ */
+function hasComponentCheckExists(node: TSESTree.CallExpression, componentName: string): boolean {
+    // Walk up to find the containing function or block
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        // Check if we're inside an if statement that checks hasComponent
+        if (current.type === 'IfStatement') {
+            const test = current.test;
+
+            // Check for hasComponent(Component) pattern
+            if (isHasComponentCall(test, componentName)) {
+                return true;
+            }
+
+            // Check for entity.hasComponent(Component) && ... pattern
+            if (test.type === 'LogicalExpression' && test.operator === '&&') {
+                if (
+                    isHasComponentCall(test.left, componentName) ||
+                    isHasComponentCall(test.right, componentName)
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        // Check for conditional expression: hasComponent(X) ? getComponent(X) : ...
+        if (current.type === 'ConditionalExpression') {
+            if (isHasComponentCall(current.test, componentName)) {
+                return true;
+            }
+        }
+
+        // Check for optional chaining: entity?.getComponent(X)
+        if (current.type === 'ChainExpression') {
+            return true;
+        }
+
+        current = current.parent;
+
+        // Stop at function boundaries
+        if (
+            current?.type === 'FunctionDeclaration' ||
+            current?.type === 'FunctionExpression' ||
+            current?.type === 'ArrowFunctionExpression' ||
+            current?.type === 'MethodDefinition'
+        ) {
+            break;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Check if a node is a hasComponent call for the given component
+ */
+function isHasComponentCall(node: TSESTree.Node | undefined, componentName: string): boolean {
+    if (!node) return false;
+
+    if (node.type === 'CallExpression') {
+        if (
+            node.callee.type === 'MemberExpression' &&
+            node.callee.property.type === 'Identifier' &&
+            node.callee.property.name === 'hasComponent'
+        ) {
+            // Check the component argument
+            const arg = node.arguments[0];
+            if (arg?.type === 'Identifier' && arg.name === componentName) {
+                return true;
+            }
+        }
+    }
+
+    // Handle negation: !entity.hasComponent(X)
+    if (node.type === 'UnaryExpression' && node.operator === '!') {
+        return isHasComponentCall(node.argument, componentName);
+    }
+
+    return false;
+}
+
+/**
+ * Get component name from argument
+ */
+function getComponentNameFromArg(node: TSESTree.Node | undefined): string | null {
+    if (!node) return null;
+    if (node.type === 'Identifier') return node.name;
+    return null;
+}
+
+/**
+ * Check if we're inside a system act callback with query-guaranteed components
+ */
+function getQueryGuaranteedComponents(node: TSESTree.Node): Set<string> {
+    const guaranteed = new Set<string>();
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        if (current.type === 'ArrowFunctionExpression' || current.type === 'FunctionExpression') {
+            const parent = current.parent;
+
+            if (parent?.type === 'Property' && parent.key.type === 'Identifier') {
+                if (parent.key.name === 'act') {
+                    // Find the createSystem call and extract query components
+                    let objParent: TSESTree.Node | undefined = parent.parent;
+
+                    while (objParent && objParent.type !== 'ObjectExpression') {
+                        objParent = objParent.parent;
+                    }
+
+                    if (objParent?.type === 'ObjectExpression') {
+                        const callExpr = objParent.parent;
+
+                        if (callExpr?.type === 'CallExpression') {
+                            const callee = callExpr.callee;
+                            if (
+                                callee.type === 'MemberExpression' &&
+                                callee.property.type === 'Identifier' &&
+                                callee.property.name === 'createSystem'
+                            ) {
+                                // Get query argument (second arg)
+                                const queryArg = callExpr.arguments[1];
+                                if (queryArg?.type === 'ObjectExpression') {
+                                    for (const prop of queryArg.properties) {
+                                        if (
+                                            prop.type === 'Property' &&
+                                            prop.key.type === 'Identifier' &&
+                                            prop.key.name === 'all' &&
+                                            prop.value.type === 'ArrayExpression'
+                                        ) {
+                                            for (const elem of prop.value.elements) {
+                                                if (elem?.type === 'Identifier') {
+                                                    guaranteed.add(elem.name);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        current = current.parent;
+    }
+
+    return guaranteed;
+}
+
+/**
+ * Rule: require-hasComponent-before-getComponent
+ *
+ * Ensures that getComponent is preceded by a hasComponent check when
+ * accessing components that aren't guaranteed by a system query.
+ * This prevents runtime errors from accessing non-existent components.
+ */
+export const requireHasComponentBeforeGetComponent = createRule<Options, MessageIds>({
+    name: 'require-hasComponent-before-getComponent',
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Require hasComponent check before getComponent for non-query-guaranteed components',
+        },
+        messages: {
+            missingHasComponentCheck:
+                'Call to getComponent({{componentName}}) without prior hasComponent check. Either add "if (entity.hasComponent({{componentName}}))" or use a system query to guarantee the component exists.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    queryGuaranteedComponents: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Components guaranteed by query (skip check)',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            queryGuaranteedComponents: [],
+        },
+    ],
+    create(context, [options]) {
+        const alwaysGuaranteed = new Set(options.queryGuaranteedComponents || []);
+
+        return {
+            CallExpression(node) {
+                // Check for entity.getComponent(Component) pattern
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+                if (node.callee.property.name !== 'getComponent') return;
+
+                const componentName = getComponentNameFromArg(node.arguments[0]);
+                if (!componentName) return;
+
+                // Skip if always guaranteed
+                if (alwaysGuaranteed.has(componentName)) return;
+
+                // Get components guaranteed by enclosing system query
+                const queryGuaranteed = getQueryGuaranteedComponents(node);
+                if (queryGuaranteed.has(componentName)) return;
+
+                // Check if there's a hasComponent check
+                if (hasComponentCheckExists(node, componentName)) return;
+
+                context.report({
+                    node,
+                    messageId: 'missingHasComponentCheck',
+                    data: { componentName },
+                });
+            },
+        };
+    },
+});
+
+export default requireHasComponentBeforeGetComponent;

--- a/packages/eslint-plugin-ecs/src/rules/singleton-mark-dirty.ts
+++ b/packages/eslint-plugin-ecs/src/rules/singleton-mark-dirty.ts
@@ -1,0 +1,175 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'missingSingletonDirtyMark';
+
+type Options = [
+    {
+        /** Whether to check for markSingletonDirty after property modifications */
+        strictMode?: boolean;
+    },
+];
+
+interface SingletonAccess {
+    node: TSESTree.CallExpression;
+    singletonType: string;
+    variableName: string | null;
+}
+
+interface SingletonModification {
+    node: TSESTree.AssignmentExpression;
+    variableName: string;
+}
+
+/**
+ * Get the singleton type from getSingleton argument
+ */
+function getSingletonType(node: TSESTree.CallExpression): string | null {
+    const arg = node.arguments[0];
+    if (arg?.type === 'Identifier') {
+        return arg.name;
+    }
+    return null;
+}
+
+/**
+ * Get the variable name from an assignment
+ */
+function getAssignedVariableName(node: TSESTree.CallExpression): string | null {
+    const parent = node.parent;
+
+    // const x = getSingleton(...)
+    if (parent?.type === 'VariableDeclarator' && parent.id.type === 'Identifier') {
+        return parent.id.name;
+    }
+
+    // x = getSingleton(...)
+    if (parent?.type === 'AssignmentExpression' && parent.left.type === 'Identifier') {
+        return parent.left.name;
+    }
+
+    return null;
+}
+
+/**
+ * Check if a node modifies a singleton variable
+ */
+function isSingletonModification(node: TSESTree.AssignmentExpression): {
+    modified: boolean;
+    variableName: string | null;
+} {
+    // x.property = value
+    if (node.left.type === 'MemberExpression') {
+        const obj = node.left.object;
+        if (obj.type === 'Identifier') {
+            return { modified: true, variableName: obj.name };
+        }
+    }
+    return { modified: false, variableName: null };
+}
+
+/**
+ * Rule: singleton-mark-dirty
+ *
+ * Ensures that after modifying a singleton's properties,
+ * markSingletonDirty is called to notify listeners of the change.
+ * Without this call, systems watching for singleton changes won't be notified.
+ */
+export const singletonMarkDirty = createRule<Options, MessageIds>({
+    name: 'singleton-mark-dirty',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Require markSingletonDirty after modifying singleton properties',
+        },
+        messages: {
+            missingSingletonDirtyMark:
+                'Singleton "{{singletonType}}" was modified but markSingletonDirty({{singletonType}}) was not called. Listeners won\'t be notified of the change.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    strictMode: {
+                        type: 'boolean',
+                        description: 'Whether to check for markSingletonDirty after modifications',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            strictMode: true,
+        },
+    ],
+    create(context) {
+        // Track getSingleton calls and their variable assignments
+        const singletonAccesses = new Map<string, SingletonAccess>();
+        // Track modifications to singleton variables
+        const modifications: SingletonModification[] = [];
+        // Track markSingletonDirty calls
+        const dirtyMarks = new Set<string>();
+
+        return {
+            // Track getSingleton calls
+            CallExpression(node) {
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const methodName = node.callee.property.name;
+
+                if (methodName === 'getSingleton') {
+                    const singletonType = getSingletonType(node);
+                    const variableName = getAssignedVariableName(node);
+
+                    if (singletonType && variableName) {
+                        singletonAccesses.set(variableName, {
+                            node,
+                            singletonType,
+                            variableName,
+                        });
+                    }
+                }
+
+                if (methodName === 'markSingletonDirty') {
+                    const singletonType = getSingletonType(node);
+                    if (singletonType) {
+                        dirtyMarks.add(singletonType);
+                    }
+                }
+            },
+
+            // Track modifications to singleton variables
+            AssignmentExpression(node) {
+                const { modified, variableName } = isSingletonModification(node);
+                if (modified && variableName) {
+                    modifications.push({ node, variableName });
+                }
+            },
+
+            // Check at end of program
+            'Program:exit'() {
+                for (const mod of modifications) {
+                    const access = singletonAccesses.get(mod.variableName);
+                    if (!access) continue;
+
+                    // Check if markSingletonDirty was called for this singleton type
+                    if (!dirtyMarks.has(access.singletonType)) {
+                        context.report({
+                            node: mod.node,
+                            messageId: 'missingSingletonDirtyMark',
+                            data: { singletonType: access.singletonType },
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+export default singletonMarkDirty;

--- a/packages/eslint-plugin-ecs/src/rules/subscription-cleanup-required.ts
+++ b/packages/eslint-plugin-ecs/src/rules/subscription-cleanup-required.ts
@@ -1,0 +1,357 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'subscriptionNotStored' | 'subscriptionNotCleanedUp' | 'missingUninstallMethod';
+
+type Options = [
+    {
+        /** Pattern to identify plugin classes */
+        pluginPattern?: string;
+        /** Additional subscription method names */
+        subscriptionMethods?: string[];
+    },
+];
+
+interface SubscriptionInfo {
+    node: TSESTree.CallExpression;
+    methodName: string;
+    isStored: boolean;
+    storedFieldName?: string;
+}
+
+interface PluginInfo {
+    className: string;
+    classNode: TSESTree.ClassDeclaration;
+    subscriptions: SubscriptionInfo[];
+    hasUninstall: boolean;
+    cleanedUpFields: Set<string>;
+}
+
+/**
+ * Check if a call is inside an 'install' method
+ */
+function isInsideInstallMethod(node: TSESTree.Node): boolean {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        if (current.type === 'MethodDefinition') {
+            if (current.key.type === 'Identifier' && current.key.name === 'install') {
+                return true;
+            }
+        }
+        current = current.parent;
+    }
+
+    return false;
+}
+
+/**
+ * Check if a call result is being stored
+ */
+function isCallResultStored(node: TSESTree.CallExpression): {
+    stored: boolean;
+    fieldName?: string;
+} {
+    const parent = node.parent;
+
+    // Check for assignment to this.field
+    if (parent?.type === 'AssignmentExpression' && parent.left.type === 'MemberExpression') {
+        if (
+            parent.left.object.type === 'ThisExpression' &&
+            parent.left.property.type === 'Identifier'
+        ) {
+            return { stored: true, fieldName: parent.left.property.name };
+        }
+    }
+
+    // Check for variable declaration
+    if (parent?.type === 'VariableDeclarator' && parent.id.type === 'Identifier') {
+        return { stored: true, fieldName: parent.id.name };
+    }
+
+    // Check for property in object pattern (destructuring)
+    if (parent?.type === 'Property') {
+        return { stored: true };
+    }
+
+    return { stored: false };
+}
+
+/**
+ * Check if a class implements EnginePlugin
+ */
+function isPluginClass(node: TSESTree.ClassDeclaration, pluginPattern: RegExp): boolean {
+    if (!node.id) return false;
+
+    // Check pattern match
+    if (pluginPattern.test(node.id.name)) {
+        return true;
+    }
+
+    // Check implements clause
+    if (node.implements) {
+        for (const impl of node.implements) {
+            if (impl.expression.type === 'Identifier') {
+                if (impl.expression.name === 'EnginePlugin') {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Walk all nodes in a tree
+ */
+function walkNode(node: TSESTree.Node, callback: (node: TSESTree.Node) => void): void {
+    callback(node);
+
+    for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+
+        const child = (node as Record<string, unknown>)[key];
+        if (child && typeof child === 'object') {
+            if (Array.isArray(child)) {
+                for (const item of child) {
+                    if (item && typeof item === 'object' && 'type' in item) {
+                        walkNode(item as TSESTree.Node, callback);
+                    }
+                }
+            } else if ('type' in child) {
+                walkNode(child as TSESTree.Node, callback);
+            }
+        }
+    }
+}
+
+/**
+ * Find fields accessed in uninstall method
+ */
+function findCleanedUpFieldsInUninstall(classNode: TSESTree.ClassDeclaration): Set<string> {
+    const cleanedFields = new Set<string>();
+
+    for (const member of classNode.body.body) {
+        if (
+            member.type === 'MethodDefinition' &&
+            member.key.type === 'Identifier' &&
+            member.key.name === 'uninstall'
+        ) {
+            // Walk the method body to find this.field() or this.field?.() calls
+            const body = (member.value as TSESTree.FunctionExpression).body;
+            if (body) {
+                walkNode(body, (node) => {
+                    // Look for this.field() or this.field?.()
+                    if (node.type === 'CallExpression') {
+                        let callee = node.callee;
+
+                        // Handle optional chaining
+                        if (callee.type === 'ChainExpression') {
+                            callee = callee.expression;
+                        }
+
+                        if (callee.type === 'MemberExpression') {
+                            if (
+                                callee.object.type === 'ThisExpression' &&
+                                callee.property.type === 'Identifier'
+                            ) {
+                                cleanedFields.add(callee.property.name);
+                            }
+                        }
+                    }
+
+                    // Look for this.field?.unsubscribe()
+                    if (
+                        node.type === 'MemberExpression' &&
+                        node.object.type === 'ThisExpression' &&
+                        node.property.type === 'Identifier'
+                    ) {
+                        // Check if parent is a call or member access to unsubscribe
+                        const parent = node.parent;
+                        if (parent?.type === 'MemberExpression') {
+                            cleanedFields.add(node.property.name);
+                        }
+                    }
+                });
+            }
+            break;
+        }
+    }
+
+    return cleanedFields;
+}
+
+/**
+ * Check if class has uninstall method
+ */
+function hasUninstallMethod(classNode: TSESTree.ClassDeclaration): boolean {
+    for (const member of classNode.body.body) {
+        if (
+            member.type === 'MethodDefinition' &&
+            member.key.type === 'Identifier' &&
+            member.key.name === 'uninstall'
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Get the enclosing class
+ */
+function getEnclosingClass(node: TSESTree.Node): TSESTree.ClassDeclaration | null {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        if (current.type === 'ClassDeclaration') {
+            return current;
+        }
+        current = current.parent;
+    }
+
+    return null;
+}
+
+/**
+ * Rule: subscription-cleanup-required
+ *
+ * Ensures that event subscriptions in plugin classes are properly stored
+ * and cleaned up in the uninstall method. This prevents memory leaks.
+ */
+export const subscriptionCleanupRequired = createRule<Options, MessageIds>({
+    name: 'subscription-cleanup-required',
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Require event subscriptions in plugins to be stored and cleaned up in uninstall',
+        },
+        messages: {
+            subscriptionNotStored:
+                'Subscription from "{{methodName}}" is not stored. Store the unsubscribe function to clean it up in uninstall().',
+            subscriptionNotCleanedUp:
+                'Subscription stored in "{{fieldName}}" is not cleaned up in uninstall(). Call "this.{{fieldName}}?.()" or "this.{{fieldName}}?.unsubscribe()" in uninstall().',
+            missingUninstallMethod:
+                'Plugin class "{{className}}" has subscriptions but no uninstall() method. Add an uninstall() method to clean up subscriptions.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    pluginPattern: {
+                        type: 'string',
+                        description: 'Regex pattern to identify plugin classes',
+                    },
+                    subscriptionMethods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Additional subscription method names',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            pluginPattern: 'Plugin$',
+            subscriptionMethods: [],
+        },
+    ],
+    create(context, [options]) {
+        const pluginPattern = new RegExp(options.pluginPattern || 'Plugin$');
+
+        // Subscription methods that return unsubscribe functions
+        const subscriptionMethods = new Set([
+            'on', // context.on, engine.on
+            'subscribe', // messageBus.subscribe
+            'addEventListener',
+            ...(options.subscriptionMethods || []),
+        ]);
+
+        // Track plugins in this file
+        const plugins = new Map<string, PluginInfo>();
+
+        return {
+            ClassDeclaration(node) {
+                if (!isPluginClass(node, pluginPattern) || !node.id) return;
+
+                plugins.set(node.id.name, {
+                    className: node.id.name,
+                    classNode: node,
+                    subscriptions: [],
+                    hasUninstall: hasUninstallMethod(node),
+                    cleanedUpFields: findCleanedUpFieldsInUninstall(node),
+                });
+            },
+
+            CallExpression(node) {
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const methodName = node.callee.property.name;
+
+                if (!subscriptionMethods.has(methodName)) return;
+                if (!isInsideInstallMethod(node)) return;
+
+                const enclosingClass = getEnclosingClass(node);
+                if (!enclosingClass || !enclosingClass.id) return;
+
+                const plugin = plugins.get(enclosingClass.id.name);
+                if (!plugin) return;
+
+                const { stored, fieldName } = isCallResultStored(node);
+
+                plugin.subscriptions.push({
+                    node,
+                    methodName,
+                    isStored: stored,
+                    storedFieldName: fieldName,
+                });
+            },
+
+            'Program:exit'() {
+                for (const plugin of plugins.values()) {
+                    if (plugin.subscriptions.length === 0) continue;
+
+                    // Check for missing uninstall method
+                    if (!plugin.hasUninstall) {
+                        context.report({
+                            node: plugin.classNode,
+                            messageId: 'missingUninstallMethod',
+                            data: { className: plugin.className },
+                        });
+                        continue;
+                    }
+
+                    // Check each subscription
+                    for (const sub of plugin.subscriptions) {
+                        if (!sub.isStored) {
+                            context.report({
+                                node: sub.node,
+                                messageId: 'subscriptionNotStored',
+                                data: { methodName: sub.methodName },
+                            });
+                        } else if (
+                            sub.storedFieldName &&
+                            !plugin.cleanedUpFields.has(sub.storedFieldName)
+                        ) {
+                            context.report({
+                                node: sub.node,
+                                messageId: 'subscriptionNotCleanedUp',
+                                data: { fieldName: sub.storedFieldName },
+                            });
+                        }
+                    }
+                }
+            },
+        };
+    },
+});
+
+export default subscriptionCleanupRequired;

--- a/packages/eslint-plugin-ecs/src/rules/system-naming-convention.ts
+++ b/packages/eslint-plugin-ecs/src/rules/system-naming-convention.ts
@@ -1,0 +1,113 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'systemNamingSuffix' | 'systemNamingCase';
+
+type Options = [
+    {
+        /** Required suffix for system names */
+        requiredSuffix?: string;
+        /** Require PascalCase naming */
+        requirePascalCase?: boolean;
+    },
+];
+
+/**
+ * Check if a string is PascalCase
+ */
+function isPascalCase(str: string): boolean {
+    return /^[A-Z][a-zA-Z0-9]*$/.test(str);
+}
+
+/**
+ * Rule: system-naming-convention
+ *
+ * Enforces consistent naming for systems, typically requiring
+ * names to end with 'System' suffix and use PascalCase.
+ */
+export const systemNamingConvention = createRule<Options, MessageIds>({
+    name: 'system-naming-convention',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Enforce consistent system naming conventions',
+        },
+        messages: {
+            systemNamingSuffix:
+                'System name "{{systemName}}" should end with "{{requiredSuffix}}". Consider renaming to "{{suggestedName}}".',
+            systemNamingCase:
+                'System name "{{systemName}}" should use PascalCase (e.g., "MovementSystem").',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    requiredSuffix: {
+                        type: 'string',
+                        description: 'Required suffix for system names',
+                    },
+                    requirePascalCase: {
+                        type: 'boolean',
+                        description: 'Require PascalCase naming',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            requiredSuffix: 'System',
+            requirePascalCase: true,
+        },
+    ],
+    create(context, [options]) {
+        const requiredSuffix = options.requiredSuffix ?? 'System';
+        const requirePascalCase = options.requirePascalCase ?? true;
+
+        return {
+            CallExpression(node) {
+                // Check for engine.createSystem calls
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+                if (node.callee.property.name !== 'createSystem') return;
+
+                // Get system name (first argument)
+                const nameArg = node.arguments[0];
+                if (!nameArg) return;
+                if (nameArg.type !== 'Literal') return;
+                if (typeof nameArg.value !== 'string') return;
+
+                const systemName = nameArg.value;
+
+                // Check suffix
+                if (!systemName.endsWith(requiredSuffix)) {
+                    const suggestedName = systemName + requiredSuffix;
+                    context.report({
+                        node: nameArg,
+                        messageId: 'systemNamingSuffix',
+                        data: {
+                            systemName,
+                            requiredSuffix,
+                            suggestedName,
+                        },
+                    });
+                }
+
+                // Check PascalCase
+                if (requirePascalCase && !isPascalCase(systemName)) {
+                    context.report({
+                        node: nameArg,
+                        messageId: 'systemNamingCase',
+                        data: { systemName },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default systemNamingConvention;

--- a/packages/eslint-plugin-ecs/src/rules/system-priority-explicit.ts
+++ b/packages/eslint-plugin-ecs/src/rules/system-priority-explicit.ts
@@ -1,0 +1,127 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'missingPriority';
+
+type Options = [
+    {
+        /** Default priority value to suggest */
+        suggestedDefault?: number;
+    },
+];
+
+/**
+ * Find a property in an object expression
+ */
+function findProperty(
+    obj: TSESTree.ObjectExpression,
+    propName: string
+): TSESTree.Property | undefined {
+    for (const prop of obj.properties) {
+        if (
+            prop.type === 'Property' &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === propName
+        ) {
+            return prop;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Rule: system-priority-explicit
+ *
+ * Requires system creation to explicitly specify a priority value.
+ * Implicit priority (defaulting to 0) can lead to unclear system
+ * execution order. Explicit priorities make the intended order clear.
+ */
+export const systemPriorityExplicit = createRule<Options, MessageIds>({
+    name: 'system-priority-explicit',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Require explicit priority when creating systems',
+        },
+        messages: {
+            missingPriority:
+                'System "{{systemName}}" is missing an explicit priority. Add "priority: {{suggestedDefault}}" to specify execution order.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    suggestedDefault: {
+                        type: 'number',
+                        description: 'Default priority value to suggest',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            suggestedDefault: 0,
+        },
+    ],
+    create(context, [options]) {
+        return {
+            CallExpression(node) {
+                // Check for engine.createSystem calls
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+                if (node.callee.property.name !== 'createSystem') return;
+
+                // Only check when called on 'engine' or common engine variable names
+                const obj = node.callee.object;
+                if (obj.type === 'Identifier') {
+                    const name = obj.name.toLowerCase();
+                    if (!['engine', 'game', 'world', 'ecs'].includes(name)) {
+                        return; // Skip non-engine objects
+                    }
+                }
+
+                // Get system name (first argument)
+                let systemName = 'System';
+                const nameArg = node.arguments[0];
+                if (nameArg?.type === 'Literal' && typeof nameArg.value === 'string') {
+                    systemName = nameArg.value;
+                }
+
+                // Get options object (third argument)
+                const optionsArg = node.arguments[2];
+                if (!optionsArg || optionsArg.type !== 'ObjectExpression') {
+                    // No options object provided
+                    context.report({
+                        node,
+                        messageId: 'missingPriority',
+                        data: {
+                            systemName,
+                            suggestedDefault: options.suggestedDefault,
+                        },
+                    });
+                    return;
+                }
+
+                // Check if priority is specified
+                const priorityProp = findProperty(optionsArg, 'priority');
+                if (!priorityProp) {
+                    context.report({
+                        node: optionsArg,
+                        messageId: 'missingPriority',
+                        data: {
+                            systemName,
+                            suggestedDefault: options.suggestedDefault,
+                        },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default systemPriorityExplicit;

--- a/packages/eslint-plugin-ecs/src/rules/use-command-buffer-in-system.ts
+++ b/packages/eslint-plugin-ecs/src/rules/use-command-buffer-in-system.ts
@@ -1,0 +1,233 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'useCommandBufferForCreate' | 'useCommandBufferForMutation';
+
+type Options = [
+    {
+        /** Method names that create entities */
+        createMethods?: string[];
+        /** Method names that mutate entities */
+        mutationMethods?: string[];
+    },
+];
+
+/**
+ * Check if a node is inside a system callback (act, before, after)
+ */
+function isInsideSystemCallback(node: TSESTree.Node): {
+    isInside: boolean;
+    callbackType: string | null;
+} {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        if (current.type === 'ArrowFunctionExpression' || current.type === 'FunctionExpression') {
+            const parent = current.parent;
+
+            if (parent?.type === 'Property' && parent.key.type === 'Identifier') {
+                const propName = parent.key.name;
+
+                if (['act', 'before', 'after'].includes(propName)) {
+                    let objParent: TSESTree.Node | undefined = parent.parent;
+
+                    while (objParent && objParent.type !== 'ObjectExpression') {
+                        objParent = objParent.parent;
+                    }
+
+                    if (objParent?.type === 'ObjectExpression') {
+                        const callExpr = objParent.parent;
+
+                        if (callExpr?.type === 'CallExpression') {
+                            const callee = callExpr.callee;
+                            if (
+                                callee.type === 'MemberExpression' &&
+                                callee.property.type === 'Identifier' &&
+                                callee.property.name === 'createSystem'
+                            ) {
+                                return { isInside: true, callbackType: propName };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        current = current.parent;
+    }
+
+    return { isInside: false, callbackType: null };
+}
+
+/**
+ * Check if a call expression is part of a command buffer chain
+ * e.g., engine.commands.entity(e).add(X).addTag('foo')
+ */
+function isCommandBufferChain(node: TSESTree.Node): boolean {
+    let current: TSESTree.Node | undefined = node;
+
+    while (current) {
+        if (current.type === 'MemberExpression') {
+            // Check for .commands property
+            if (current.property.type === 'Identifier' && current.property.name === 'commands') {
+                return true;
+            }
+            current = current.object;
+        } else if (current.type === 'CallExpression') {
+            // Check if callee is a member expression to continue chain
+            if (current.callee.type === 'MemberExpression') {
+                current = current.callee.object;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Rule: use-command-buffer-in-system
+ *
+ * Requires using command buffer for entity creation and mutation inside
+ * system callbacks. Direct entity operations during system iteration can
+ * cause iterator invalidation and archetype transition issues.
+ */
+export const useCommandBufferInSystem = createRule<Options, MessageIds>({
+    name: 'use-command-buffer-in-system',
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Require using command buffer for entity operations inside system callbacks',
+        },
+        messages: {
+            useCommandBufferForCreate:
+                'Avoid calling "{{methodName}}" directly inside system callbacks. Use "engine.commands.spawn()" instead to safely create entities during iteration.',
+            useCommandBufferForMutation:
+                'Avoid calling "{{methodName}}" directly inside system callbacks. Use "engine.commands.entity(entity).{{suggestedMethod}}()" instead to safely modify entities during iteration.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    createMethods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Method names that create entities',
+                    },
+                    mutationMethods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Method names that mutate entities',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            createMethods: [],
+            mutationMethods: [],
+        },
+    ],
+    create(context, [options]) {
+        // Methods on engine that create entities
+        const engineCreateMethods = new Set([
+            'createEntity',
+            'createEntities',
+            'createFromPrefab',
+            ...(options.createMethods || []),
+        ]);
+
+        // Methods on entity that mutate state
+        const entityMutationMethods = new Set([
+            'addComponent',
+            'removeComponent',
+            'addTag',
+            'removeTag',
+            'queueFree',
+            'destroy',
+            'setParent',
+            'addChild',
+            'removeChild',
+            ...(options.mutationMethods || []),
+        ]);
+
+        // Map mutation methods to their command buffer equivalents
+        const mutationToCommandMethod: Record<string, string> = {
+            addComponent: 'add',
+            removeComponent: 'remove',
+            addTag: 'addTag',
+            removeTag: 'removeTag',
+            queueFree: 'despawn',
+            destroy: 'despawn',
+        };
+
+        return {
+            CallExpression(node) {
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const methodName = node.callee.property.name;
+
+                // Check if we're inside a system callback
+                const { isInside } = isInsideSystemCallback(node);
+                if (!isInside) return;
+
+                // Check for engine create methods
+                if (engineCreateMethods.has(methodName)) {
+                    // Verify it's being called on engine (not command buffer)
+                    const obj = node.callee.object;
+
+                    // Skip if it's already using command buffer
+                    if (obj.type === 'MemberExpression') {
+                        if (
+                            obj.property.type === 'Identifier' &&
+                            obj.property.name === 'commands'
+                        ) {
+                            return;
+                        }
+                    }
+
+                    context.report({
+                        node,
+                        messageId: 'useCommandBufferForCreate',
+                        data: { methodName },
+                    });
+                    return;
+                }
+
+                // Check for entity mutation methods
+                if (entityMutationMethods.has(methodName)) {
+                    const obj = node.callee.object;
+
+                    // Skip if this is part of a command buffer chain
+                    // e.g., engine.commands.entity(entity).add(X).addTag('foo')
+                    if (isCommandBufferChain(obj)) {
+                        return;
+                    }
+
+                    const suggestedMethod = mutationToCommandMethod[methodName] || methodName;
+
+                    context.report({
+                        node,
+                        messageId: 'useCommandBufferForMutation',
+                        data: {
+                            methodName,
+                            suggestedMethod,
+                        },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default useCommandBufferInSystem;


### PR DESCRIPTION
Add comprehensive set of ESLint rules to enforce ECS framework patterns:

Phase 1 - Critical Safety Rules:
- no-query-in-act-callback: Prevent expensive query creation in system callbacks
- use-command-buffer-in-system: Require command buffer for entity operations in systems
- subscription-cleanup-required: Ensure plugin subscriptions are properly cleaned up

Phase 2 - Correctness Rules:
- require-hasComponent-before-getComponent: Require safety checks before component access
- singleton-mark-dirty: Ensure singletons notify listeners on changes
- no-async-in-system-callbacks: Prevent async/await in system callbacks

Phase 3 - Best Practice Rules:
- plugin-structure-validation: Validate plugin class structure (name, version, install)
- system-priority-explicit: Require explicit system priorities
- component-lifecycle-complete: Check onCreate/onDestroy pairing
- no-magic-tag-strings: Discourage inline tag string literals
- prefer-queueFree: Prefer safe deferred entity deletion
- system-naming-convention: Enforce system naming patterns
- plugin-logging-format: Enforce consistent plugin logging format
- no-nested-transactions: Prevent nested transaction errors

All rules include comprehensive tests (227 tests total) and are configured in both recommended and strict presets.