### PR TITLE
feat(eslint-plugin): Add ESLint rule for logger enforcement

### DIFF
--- a/packages/eslint-plugin-ecs/src/__tests__/prefer-engine-logger.test.ts
+++ b/packages/eslint-plugin-ecs/src/__tests__/prefer-engine-logger.test.ts
@@ -1,0 +1,248 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { preferEngineLogger } from '../rules/prefer-engine-logger';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-engine-logger', preferEngineLogger, {
+    valid: [
+        // Using engine.logger is fine
+        {
+            code: `
+        class MyPlugin implements EnginePlugin {
+          install(context) {
+            context.logger.info('Plugin installed');
+          }
+        }
+      `,
+        },
+        // Using logger.* methods
+        {
+            code: `
+        function initGame(engine) {
+          const logger = engine.logger;
+          logger.info('Game initialized');
+          logger.debug('Debug info');
+          logger.warn('Warning message');
+          logger.error('Error occurred');
+        }
+      `,
+        },
+        // Test files should be allowed by default
+        {
+            code: `
+        console.log('Testing something');
+        console.error('Test error');
+      `,
+            filename: 'myfile.spec.ts',
+        },
+        {
+            code: `
+        console.log('Testing something');
+      `,
+            filename: 'myfile.test.ts',
+        },
+        {
+            code: `
+        console.log('Testing something');
+      `,
+            filename: '__tests__/myfile.ts',
+        },
+        // console.error allowed when option is set
+        {
+            code: `
+        function handleCriticalError() {
+          console.error('Critical error!');
+        }
+      `,
+            options: [{ allowConsoleError: true }],
+        },
+        // Non-logging console methods are not flagged by default
+        {
+            code: `
+        console.time('benchmark');
+        console.timeEnd('benchmark');
+        console.trace();
+        console.clear();
+      `,
+        },
+        // Custom methods list excludes certain methods
+        {
+            code: `
+        function debug() {
+          console.log('Debug info');
+        }
+      `,
+            options: [{ methods: ['warn', 'error'], allowInTests: false }],
+            filename: 'src/system.ts',
+        },
+    ],
+    invalid: [
+        // Basic console.log usage
+        {
+            code: `
+        function init() {
+          console.log('Initializing');
+        }
+      `,
+            filename: 'src/game.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // console.warn usage
+        {
+            code: `
+        function checkHealth(health) {
+          if (health < 10) {
+            console.warn('Low health!');
+          }
+        }
+      `,
+            filename: 'src/health.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // console.error usage
+        {
+            code: `
+        function processEntity(entity) {
+          if (!entity) {
+            console.error('Entity is null');
+          }
+        }
+      `,
+            filename: 'src/entity.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // console.info usage
+        {
+            code: `
+        function start() {
+          console.info('Starting game');
+        }
+      `,
+            filename: 'src/start.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // console.debug usage
+        {
+            code: `
+        function update(dt) {
+          console.debug('Delta time:', dt);
+        }
+      `,
+            filename: 'src/update.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // Multiple console statements
+        {
+            code: `
+        function gameLoop() {
+          console.log('Loop start');
+          console.debug('Processing entities');
+          console.log('Loop end');
+        }
+      `,
+            filename: 'src/loop.ts',
+            errors: [
+                { messageId: 'preferEngineLogger' },
+                { messageId: 'preferEngineLogger' },
+                { messageId: 'preferEngineLogger' },
+            ],
+        },
+        // Inside a Plugin class
+        {
+            code: `
+        class PhysicsPlugin implements EnginePlugin {
+          install(context) {
+            console.log('Physics initialized');
+          }
+        }
+      `,
+            filename: 'src/plugins/physics.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // Inside a System class
+        {
+            code: `
+        class MovementSystem {
+          update(entities) {
+            console.log('Processing movement');
+          }
+        }
+      `,
+            filename: 'src/systems/movement.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // Inside a Manager class
+        {
+            code: `
+        class EntityManager {
+          createEntity() {
+            console.log('Creating entity');
+            return {};
+          }
+        }
+      `,
+            filename: 'src/managers/entity.ts',
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // Inside system callback (createSystem)
+        {
+            code: `
+        engine.createSystem('Movement', { all: [Position, Velocity] }, {
+          act: (entity, pos, vel) => {
+            console.log('Moving entity');
+            pos.x += vel.x;
+          }
+        });
+      `,
+            filename: 'src/systems.ts',
+            errors: [{ messageId: 'preferEngineLoggerInSystem' }],
+        },
+        // Inside system before callback
+        {
+            code: `
+        engine.createSystem('Physics', { all: [RigidBody] }, {
+          before: () => {
+            console.log('Before physics update');
+          },
+          act: (entity) => {}
+        });
+      `,
+            filename: 'src/systems.ts',
+            errors: [{ messageId: 'preferEngineLoggerInSystem' }],
+        },
+        // Inside system after callback
+        {
+            code: `
+        engine.createSystem('Render', { all: [Sprite] }, {
+          act: (entity) => {},
+          after: () => {
+            console.debug('Render complete');
+          }
+        });
+      `,
+            filename: 'src/systems.ts',
+            errors: [{ messageId: 'preferEngineLoggerInSystem' }],
+        },
+        // Test files not allowed when option is false
+        {
+            code: `
+        console.log('This should be flagged');
+      `,
+            filename: 'src/game.spec.ts',
+            options: [{ allowInTests: false }],
+            errors: [{ messageId: 'preferEngineLogger' }],
+        },
+        // Custom methods list
+        {
+            code: `
+        function debug() {
+          console.warn('Warning');
+          console.error('Error');
+        }
+      `,
+            options: [{ methods: ['warn', 'error'], allowInTests: false }],
+            filename: 'src/debug.ts',
+            errors: [{ messageId: 'preferEngineLogger' }, { messageId: 'preferEngineLogger' }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-ecs/src/index.ts
+++ b/packages/eslint-plugin-ecs/src/index.ts
@@ -16,6 +16,7 @@ import { pluginLoggingFormat } from './rules/plugin-logging-format';
 // Phase 3: Best Practice Rules
 import { pluginStructureValidation } from './rules/plugin-structure-validation';
 import { preferComposition } from './rules/prefer-composition';
+import { preferEngineLogger } from './rules/prefer-engine-logger';
 import { preferQueueFree } from './rules/prefer-queueFree';
 import { queryValidator } from './rules/query-validator';
 // Phase 2: Correctness Rules
@@ -57,6 +58,7 @@ export const rules = {
     'system-naming-convention': systemNamingConvention,
     'plugin-logging-format': pluginLoggingFormat,
     'no-nested-transactions': noNestedTransactions,
+    'prefer-engine-logger': preferEngineLogger,
 };
 
 // Recommended configuration - warns on most rules
@@ -90,6 +92,7 @@ const recommendedRules = {
     '@orion-ecs/ecs/system-naming-convention': 'off', // Off by default, style preference
     '@orion-ecs/ecs/plugin-logging-format': 'off', // Off by default, style preference
     '@orion-ecs/ecs/no-nested-transactions': 'error', // Prevents runtime errors
+    '@orion-ecs/ecs/prefer-engine-logger': 'warn', // Encourages secure, consistent logging
 } as const;
 
 // Strict configuration - errors on most rules
@@ -123,6 +126,7 @@ const strictRules = {
     '@orion-ecs/ecs/system-naming-convention': 'warn',
     '@orion-ecs/ecs/plugin-logging-format': 'warn',
     '@orion-ecs/ecs/no-nested-transactions': 'error',
+    '@orion-ecs/ecs/prefer-engine-logger': 'error', // Enforces secure, consistent logging
 } as const;
 
 // Export configurations

--- a/packages/eslint-plugin-ecs/src/rules/prefer-engine-logger.ts
+++ b/packages/eslint-plugin-ecs/src/rules/prefer-engine-logger.ts
@@ -1,0 +1,238 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `https://github.com/tyevco/OrionECS/blob/main/docs/eslint-rules/${name}.md`
+);
+
+type MessageIds = 'preferEngineLogger' | 'preferEngineLoggerInSystem';
+
+type Options = [
+    {
+        /** Console methods to check (default: all logging methods) */
+        methods?: string[];
+        /** Allow console statements in test files */
+        allowInTests?: boolean;
+        /** Allow console.error for critical errors */
+        allowConsoleError?: boolean;
+    },
+];
+
+/**
+ * Check if the file path looks like a test file
+ */
+function isTestFile(filename: string): boolean {
+    return (
+        filename.includes('.spec.') ||
+        filename.includes('.test.') ||
+        filename.includes('__tests__') ||
+        filename.includes('/test/') ||
+        filename.includes('/tests/')
+    );
+}
+
+/**
+ * Check if we're inside a system callback (act, before, after, etc.)
+ */
+function isInsideSystemCallback(node: TSESTree.Node): boolean {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        // Check if we're in a function that's a property of an object passed to createSystem
+        if (current.type === 'ArrowFunctionExpression' || current.type === 'FunctionExpression') {
+            const parent = current.parent;
+
+            // Check if this function is a value in a Property node
+            if (parent?.type === 'Property') {
+                const propName = parent.key.type === 'Identifier' ? parent.key.name : null;
+                if (
+                    propName &&
+                    ['act', 'before', 'after', 'onEntityAdded', 'onEntityRemoved'].includes(
+                        propName
+                    )
+                ) {
+                    // Check if this property is in an object passed to createSystem
+                    const objExpr = parent.parent;
+                    if (objExpr?.type === 'ObjectExpression') {
+                        const callExpr = objExpr.parent;
+                        if (callExpr?.type === 'CallExpression') {
+                            const callee = callExpr.callee;
+                            if (
+                                callee.type === 'MemberExpression' &&
+                                callee.property.type === 'Identifier' &&
+                                callee.property.name === 'createSystem'
+                            ) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        current = current.parent;
+    }
+
+    return false;
+}
+
+/**
+ * Check if we're inside a class that has access to an engine logger
+ * (Plugin classes, System classes, etc.)
+ */
+function isInsideEngineAwareClass(node: TSESTree.Node): boolean {
+    let current: TSESTree.Node | undefined = node.parent;
+
+    while (current) {
+        if (current.type === 'ClassDeclaration' || current.type === 'ClassExpression') {
+            const classNode = current as TSESTree.ClassDeclaration;
+
+            // Check class name patterns
+            if (classNode.id?.name) {
+                const name = classNode.id.name;
+                if (
+                    name.endsWith('Plugin') ||
+                    name.endsWith('System') ||
+                    name.endsWith('Manager')
+                ) {
+                    return true;
+                }
+            }
+
+            // Check if it implements EnginePlugin
+            if (classNode.implements) {
+                for (const impl of classNode.implements) {
+                    if (
+                        impl.expression.type === 'Identifier' &&
+                        impl.expression.name === 'EnginePlugin'
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+        current = current.parent;
+    }
+
+    return false;
+}
+
+/**
+ * Rule: prefer-engine-logger
+ *
+ * Discourages use of console.* statements in favor of the engine's built-in logger.
+ * The engine logger provides:
+ * - Automatic sanitization to prevent log injection attacks
+ * - Tagged logging for better organization
+ * - Log level filtering
+ * - Consistent formatting
+ */
+export const preferEngineLogger = createRule<Options, MessageIds>({
+    name: 'prefer-engine-logger',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description:
+                'Prefer using engine.logger over console statements for consistent, secure logging',
+        },
+        messages: {
+            preferEngineLogger:
+                'Avoid using console.{{method}}(). Use engine.logger.{{loggerMethod}}() instead for secure, consistent logging with automatic sanitization.',
+            preferEngineLoggerInSystem:
+                'Avoid using console.{{method}}() in system callbacks. Access the logger via engine.logger or pass it through system context.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    methods: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: 'Console methods to check',
+                    },
+                    allowInTests: {
+                        type: 'boolean',
+                        description: 'Allow console statements in test files',
+                    },
+                    allowConsoleError: {
+                        type: 'boolean',
+                        description: 'Allow console.error for critical errors',
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    defaultOptions: [
+        {
+            methods: ['log', 'info', 'warn', 'error', 'debug'],
+            allowInTests: true,
+            allowConsoleError: false,
+        },
+    ],
+    create(context, [options]) {
+        const methods = options.methods ?? ['log', 'info', 'warn', 'error', 'debug'];
+        const allowInTests = options.allowInTests ?? true;
+        const allowConsoleError = options.allowConsoleError ?? false;
+
+        const filename = context.filename ?? context.getFilename();
+
+        // Skip test files if configured to do so
+        if (allowInTests && isTestFile(filename)) {
+            return {};
+        }
+
+        return {
+            CallExpression(node) {
+                // Check for console.* calls
+                if (node.callee.type !== 'MemberExpression') return;
+                if (node.callee.object.type !== 'Identifier') return;
+                if (node.callee.object.name !== 'console') return;
+                if (node.callee.property.type !== 'Identifier') return;
+
+                const method = node.callee.property.name;
+
+                // Check if this method should be checked
+                if (!methods.includes(method)) return;
+
+                // Allow console.error if configured
+                if (allowConsoleError && method === 'error') return;
+
+                // Map console methods to logger methods
+                const loggerMethodMap: Record<string, string> = {
+                    log: 'info',
+                    info: 'info',
+                    warn: 'warn',
+                    error: 'error',
+                    debug: 'debug',
+                };
+                const loggerMethod = loggerMethodMap[method] ?? method;
+
+                // Provide more specific message if inside a system callback
+                const inSystem = isInsideSystemCallback(node);
+                const inEngineClass = isInsideEngineAwareClass(node);
+
+                if (inSystem) {
+                    context.report({
+                        node,
+                        messageId: 'preferEngineLoggerInSystem',
+                        data: { method, loggerMethod },
+                    });
+                } else if (inEngineClass) {
+                    context.report({
+                        node,
+                        messageId: 'preferEngineLogger',
+                        data: { method, loggerMethod },
+                    });
+                } else {
+                    // Still report for general code, but with the standard message
+                    context.report({
+                        node,
+                        messageId: 'preferEngineLogger',
+                        data: { method, loggerMethod },
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default preferEngineLogger;


### PR DESCRIPTION
Add ESLint rule that discourages console.* statements in favor of the engine's built-in logger. The engine logger provides:
- Automatic sanitization to prevent log injection attacks
- Tagged logging for better organization
- Log level filtering
- Consistent formatting

Options:
- methods: Console methods to check (default: all logging methods)
- allowInTests: Allow console statements in test files (default: true)
- allowConsoleError: Allow console.error for critical errors

The rule provides contextual messages for system callbacks vs general code.