### PR TITLE
feat(vscode): Start implementing VS Code Extension #95

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@orionecs/examples", "orionecs-tutorial-*"]
+  "ignore": ["@orionecs/examples", "orionecs-tutorial-*", "orion-ecs-vscode"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ publish/
 !/packages/testing/
 !/packages/utils/
 !/packages/eslint-plugin-ecs/
+!/packages/vscode-extension/
 
 # Windows Azure Build Output
 csx/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "packages/plugin-api",
         "packages/testing",
         "packages/eslint-plugin-ecs",
+        "packages/vscode-extension",
         "examples",
         "plugins/canvas2d-renderer",
         "plugins/debug-visualizer",
@@ -6008,6 +6009,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/vscode": {
+      "version": "1.106.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
+      "integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6566,6 +6574,36 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.66",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
@@ -6615,6 +6653,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -7195,6 +7243,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
@@ -7488,6 +7549,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -8808,6 +8876,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-id": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.2.tgz",
@@ -8870,6 +8966,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -9040,6 +9143,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9099,6 +9215,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -9108,6 +9237,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11149,6 +11285,52 @@
         "node": "*"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11181,6 +11363,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -11421,6 +11613,36 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -11968,6 +12190,59 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/orion-ecs-vscode": {
+      "resolved": "packages/vscode-extension",
+      "link": true
+    },
     "node_modules/orionecs-tutorial-01-first-ecs-project": {
       "resolved": "tutorials/01-first-ecs-project",
       "link": true
@@ -12124,6 +12399,13 @@
       "dependencies": {
         "quansync": "^0.2.7"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -12527,6 +12809,13 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -12949,6 +13238,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13095,6 +13391,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string_decoder": {
@@ -15253,6 +15562,20 @@
         "tsup": "^8.0.0",
         "typedoc": "^0.28.14",
         "typescript": "^5.3.0"
+      }
+    },
+    "packages/vscode-extension": {
+      "name": "orion-ecs-vscode",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/vscode": "^1.85.0",
+        "@vscode/test-electron": "^2.3.8",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
       }
     },
     "plugins/canvas2d-renderer": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "packages/plugin-api",
     "packages/testing",
     "packages/eslint-plugin-ecs",
+    "packages/vscode-extension",
     "examples",
     "plugins/canvas2d-renderer",
     "plugins/debug-visualizer",

--- a/packages/vscode-extension/.gitignore
+++ b/packages/vscode-extension/.gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+*.vsix
+coverage/
+.vscode-test/

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -1,0 +1,14 @@
+.vscode/**
+.vscode-test/**
+src/**
+**/*.ts
+**/*.map
+node_modules/**
+.gitignore
+tsconfig.json
+jest.config.js
+coverage/**
+**/__tests__/**
+*.vsix
+.eslintrc*
+.prettierrc*

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,0 +1,139 @@
+# OrionECS VS Code Extension
+
+A Visual Studio Code extension that enhances the OrionECS development experience with code snippets, IntelliSense, and developer tools.
+
+## Features
+
+### Code Snippets
+
+Quickly scaffold ECS patterns with powerful code snippets:
+
+| Prefix | Description |
+|--------|-------------|
+| `orion-component` | Create a component class |
+| `orion-system` | Create a system |
+| `orion-system-hooks` | Create a system with lifecycle hooks |
+| `orion-system-fixed` | Create a fixed-update system |
+| `orion-entity` | Create an entity |
+| `orion-prefab` | Create and register a prefab |
+| `orion-engine` | Create and configure an engine |
+| `orion-plugin` | Create a plugin |
+| `orion-singleton` | Create and use a singleton |
+| `orion-query` | Create a fluent query |
+| `orion-gameloop` | Create a game loop |
+| `orion-spawn` | Spawn entity with command buffer |
+| `orion-import` | Import OrionECS |
+
+All snippets also work with the `ecs-` prefix (e.g., `ecs-component`).
+
+### IntelliSense Enhancements
+
+- **Component completion**: Auto-complete component names in queries and entity methods
+- **System completion**: Auto-complete system names in `getSystem()` calls
+- **Method completion**: Smart completion for entity and engine methods
+- **Tag suggestions**: Common tag suggestions in tag contexts
+
+### CodeLens
+
+- **Component usage**: See how many systems and prefabs use each component
+- **System info**: Quick system type indicator
+- **Prefab info**: Quick prefab indicator
+
+### Hover Documentation
+
+Hover over ECS methods and patterns to see inline documentation:
+
+- Entity methods (`addComponent`, `getComponent`, `hasComponent`, etc.)
+- Engine methods (`createEntity`, `createSystem`, `update`, etc.)
+- Query patterns (`all`, `any`, `none`)
+- System options (`priority`, `act`, `before`, `after`)
+
+### Tree Views
+
+The OrionECS sidebar provides three tree views:
+
+1. **Components**: Lists all component classes in your project
+2. **Systems**: Lists all registered systems with their priority and query info
+3. **Entities**: Lists all entity prefabs
+
+Click any item to navigate to its definition.
+
+### Commands
+
+Access from Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
+
+| Command | Description |
+|---------|-------------|
+| `Orion: Create New Component` | Scaffold a new component with prompts |
+| `Orion: Create New System` | Scaffold a new system with prompts |
+| `Orion: Create Entity Prefab` | Scaffold a new prefab with prompts |
+| `Orion: Show Entity Inspector` | Open the entity inspector panel |
+| `Orion: Show System Execution Order` | View system execution order |
+| `Orion: Open Documentation` | Open OrionECS documentation |
+| `Orion: Refresh Entity Tree` | Refresh all tree views |
+
+## Configuration
+
+Configure the extension in your VS Code settings:
+
+```json
+{
+  "orion-ecs.enableCodeLens": true,
+  "orion-ecs.enableInlineHints": true,
+  "orion-ecs.snippetStyle": "verbose",
+  "orion-ecs.autoImport": true
+}
+```
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enableCodeLens` | boolean | `true` | Enable CodeLens for component usage |
+| `enableInlineHints` | boolean | `true` | Enable inline hints for ECS patterns |
+| `snippetStyle` | string | `"verbose"` | Style of generated snippets (`"verbose"` or `"compact"`) |
+| `autoImport` | boolean | `true` | Auto-add imports when using snippets |
+
+## Requirements
+
+- VS Code 1.85.0 or higher
+- An OrionECS project (extension activates when `@orion-ecs/core` is detected)
+
+## Installation
+
+### From VS Code Marketplace
+
+1. Open VS Code
+2. Go to Extensions (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+3. Search for "OrionECS"
+4. Click Install
+
+### From VSIX
+
+1. Download the `.vsix` file
+2. Open VS Code
+3. Go to Extensions
+4. Click the `...` menu and select "Install from VSIX..."
+5. Select the downloaded file
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build the extension
+npm run build
+
+# Watch for changes
+npm run watch
+
+# Package the extension
+npm run package
+```
+
+## Contributing
+
+Contributions are welcome! Please see the [OrionECS repository](https://github.com/tyevco/OrionECS) for contribution guidelines.
+
+## License
+
+MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/packages/vscode-extension/images/orion-icon.svg
+++ b/packages/vscode-extension/images/orion-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Orion constellation representation -->
+  <!-- Belt stars -->
+  <circle cx="8" cy="12" r="1.5" fill="currentColor" stroke="none"/>
+  <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"/>
+  <circle cx="16" cy="12" r="1.5" fill="currentColor" stroke="none"/>
+
+  <!-- Shoulder stars -->
+  <circle cx="6" cy="6" r="1.2" fill="currentColor" stroke="none"/>
+  <circle cx="18" cy="6" r="1.2" fill="currentColor" stroke="none"/>
+
+  <!-- Knee stars -->
+  <circle cx="5" cy="18" r="1.2" fill="currentColor" stroke="none"/>
+  <circle cx="19" cy="18" r="1.2" fill="currentColor" stroke="none"/>
+
+  <!-- Connection lines -->
+  <line x1="6" y1="6" x2="8" y2="12" stroke="currentColor" stroke-width="0.5" opacity="0.5"/>
+  <line x1="18" y1="6" x2="16" y2="12" stroke="currentColor" stroke-width="0.5" opacity="0.5"/>
+  <line x1="8" y1="12" x2="12" y2="12" stroke="currentColor" stroke-width="0.5" opacity="0.5"/>
+  <line x1="12" y1="12" x2="16" y2="12" stroke="currentColor" stroke-width="0.5" opacity="0.5"/>
+  <line x1="8" y1="12" x2="5" y2="18" stroke="currentColor" stroke-width="0.5" opacity="0.5"/>
+  <line x1="16" y1="12" x2="19" y2="18" stroke="currentColor" stroke-width="0.5" opacity="0.5"/>
+</svg>

--- a/packages/vscode-extension/jest.config.js
+++ b/packages/vscode-extension/jest.config.js
@@ -1,0 +1,23 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/__tests__/**',
+    '!src/extension.ts', // Extension entry requires VS Code runtime
+  ],
+  coverageDirectory: 'coverage',
+  // Mock vscode module since it's not available in unit tests
+  moduleNameMapper: {
+    '^vscode$': '<rootDir>/src/__tests__/__mocks__/vscode.ts',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: 'tsconfig.json',
+    }],
+  },
+};

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,0 +1,168 @@
+{
+  "name": "orion-ecs-vscode",
+  "displayName": "OrionECS",
+  "description": "VS Code extension for OrionECS - Entity Component System framework with snippets, IntelliSense, and developer tools",
+  "version": "0.1.0",
+  "publisher": "orion-ecs",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Snippets",
+    "Programming Languages",
+    "Other"
+  ],
+  "keywords": [
+    "ecs",
+    "entity-component-system",
+    "game-development",
+    "orion-ecs",
+    "typescript"
+  ],
+  "activationEvents": [
+    "workspaceContains:**/node_modules/@orion-ecs/core",
+    "onLanguage:typescript",
+    "onLanguage:javascript"
+  ],
+  "main": "./dist/extension.js",
+  "icon": "images/icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tyevco/OrionECS"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "orion-ecs.createComponent",
+        "title": "Orion: Create New Component"
+      },
+      {
+        "command": "orion-ecs.createSystem",
+        "title": "Orion: Create New System"
+      },
+      {
+        "command": "orion-ecs.createPrefab",
+        "title": "Orion: Create Entity Prefab"
+      },
+      {
+        "command": "orion-ecs.showEntityInspector",
+        "title": "Orion: Show Entity Inspector"
+      },
+      {
+        "command": "orion-ecs.showSystemExecutionOrder",
+        "title": "Orion: Show System Execution Order"
+      },
+      {
+        "command": "orion-ecs.openDocumentation",
+        "title": "Orion: Open Documentation"
+      },
+      {
+        "command": "orion-ecs.refreshEntityTree",
+        "title": "Orion: Refresh Entity Tree",
+        "icon": "$(refresh)"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "orion-ecs-explorer",
+          "title": "OrionECS",
+          "icon": "images/orion-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "orion-ecs-explorer": [
+        {
+          "id": "orion-ecs.entitiesView",
+          "name": "Entities"
+        },
+        {
+          "id": "orion-ecs.componentsView",
+          "name": "Components"
+        },
+        {
+          "id": "orion-ecs.systemsView",
+          "name": "Systems"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "orion-ecs.refreshEntityTree",
+          "when": "view == orion-ecs.entitiesView",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "orion-ecs.createComponent",
+          "group": "orion-ecs@1",
+          "when": "editorLangId == typescript || editorLangId == javascript"
+        },
+        {
+          "command": "orion-ecs.createSystem",
+          "group": "orion-ecs@2",
+          "when": "editorLangId == typescript || editorLangId == javascript"
+        }
+      ]
+    },
+    "snippets": [
+      {
+        "language": "typescript",
+        "path": "./snippets/typescript.json"
+      },
+      {
+        "language": "javascript",
+        "path": "./snippets/javascript.json"
+      }
+    ],
+    "configuration": {
+      "title": "OrionECS",
+      "properties": {
+        "orion-ecs.enableCodeLens": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable CodeLens for component usage information"
+        },
+        "orion-ecs.enableInlineHints": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable inline hints for ECS patterns"
+        },
+        "orion-ecs.snippetStyle": {
+          "type": "string",
+          "enum": [
+            "verbose",
+            "compact"
+          ],
+          "default": "verbose",
+          "description": "Style of generated code snippets"
+        },
+        "orion-ecs.autoImport": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically add imports when using snippets"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "build": "tsup src/extension.ts --format cjs --dts --external vscode",
+    "watch": "tsup src/extension.ts --format cjs --watch --external vscode",
+    "test": "jest",
+    "lint": "echo 'Linting handled by root biome.json'",
+    "package": "vsce package",
+    "publish": "vsce publish"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "@vscode/test-electron": "^2.3.8",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {}
+}

--- a/packages/vscode-extension/snippets/javascript.json
+++ b/packages/vscode-extension/snippets/javascript.json
@@ -1,0 +1,255 @@
+{
+  "Create Component": {
+    "prefix": ["orion-component", "ecs-component"],
+    "body": [
+      "class ${1:ComponentName} {",
+      "  constructor(${2:value} = ${3:0}) {",
+      "    this.${2:value} = ${2:value};",
+      "  }",
+      "}",
+      "",
+      "module.exports = { ${1:ComponentName} };"
+    ],
+    "description": "Create an OrionECS component class"
+  },
+  "Create Component with Multiple Properties": {
+    "prefix": ["orion-component-multi", "ecs-component-multi"],
+    "body": [
+      "class ${1:ComponentName} {",
+      "  constructor(${2:x} = ${3:0}, ${4:y} = ${5:0}) {",
+      "    this.${2:x} = ${2:x};",
+      "    this.${4:y} = ${4:y};",
+      "  }",
+      "}",
+      "",
+      "module.exports = { ${1:ComponentName} };"
+    ],
+    "description": "Create an OrionECS component with multiple properties"
+  },
+  "Create Tag Component": {
+    "prefix": ["orion-tag", "ecs-tag"],
+    "body": [
+      "const ${1:TagName} = createTagComponent('${2:$1}');"
+    ],
+    "description": "Create an OrionECS tag component"
+  },
+  "Create System": {
+    "prefix": ["orion-system", "ecs-system"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:Component}]",
+      "}, {",
+      "  priority: ${3:100},",
+      "  act: (entity, ${4:component}) => {",
+      "    ${5:// System logic}",
+      "  }",
+      "});"
+    ],
+    "description": "Create an OrionECS system"
+  },
+  "Create System with Hooks": {
+    "prefix": ["orion-system-hooks", "ecs-system-hooks"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:Component}]",
+      "}, {",
+      "  priority: ${3:100},",
+      "  before: () => {",
+      "    ${4:// Called before processing entities}",
+      "  },",
+      "  act: (entity, ${5:component}) => {",
+      "    ${6:// Process each entity}",
+      "  },",
+      "  after: () => {",
+      "    ${7:// Called after processing entities}",
+      "  }",
+      "});"
+    ],
+    "description": "Create an OrionECS system with lifecycle hooks"
+  },
+  "Create Fixed Update System": {
+    "prefix": ["orion-system-fixed", "ecs-system-fixed"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:Component}]",
+      "}, {",
+      "  priority: ${3:100},",
+      "  act: (entity, ${4:component}) => {",
+      "    ${5:// Fixed timestep logic}",
+      "  }",
+      "}, true);"
+    ],
+    "description": "Create an OrionECS fixed-update system"
+  },
+  "Create Entity": {
+    "prefix": ["orion-entity", "ecs-entity"],
+    "body": [
+      "const ${1:entity} = engine.createEntity('${2:EntityName}');",
+      "${1:entity}.addComponent(${3:Component}, ${4:args});",
+      "${1:entity}.addTag('${5:tag}');"
+    ],
+    "description": "Create an OrionECS entity"
+  },
+  "Create Entity Prefab": {
+    "prefix": ["orion-prefab", "ecs-prefab"],
+    "body": [
+      "const ${1:prefabName}Prefab = {",
+      "  name: '${2:$1}',",
+      "  components: [",
+      "    { type: ${3:Component}, args: [${4:}] }",
+      "  ],",
+      "  tags: ['${5:tag}']",
+      "};",
+      "",
+      "engine.registerPrefab('${2:$1}', ${1:prefabName}Prefab);"
+    ],
+    "description": "Create and register an entity prefab"
+  },
+  "Create Engine": {
+    "prefix": ["orion-engine", "ecs-engine"],
+    "body": [
+      "const engine = new EngineBuilder()",
+      "  .withDebugMode(${1:true})",
+      "  .withFixedUpdateFPS(${2:60})",
+      "  .withArchetypes(${3:true})",
+      "  .build();",
+      "",
+      "engine.start();"
+    ],
+    "description": "Create and configure an OrionECS engine"
+  },
+  "Game Loop": {
+    "prefix": ["orion-gameloop", "ecs-gameloop"],
+    "body": [
+      "let lastTime = 0;",
+      "",
+      "function gameLoop(timestamp) {",
+      "  const deltaTime = (timestamp - lastTime) / 1000;",
+      "  lastTime = timestamp;",
+      "",
+      "  engine.update(deltaTime);",
+      "",
+      "  requestAnimationFrame(gameLoop);",
+      "}",
+      "",
+      "requestAnimationFrame(gameLoop);"
+    ],
+    "description": "Create a game loop for OrionECS"
+  },
+  "Create Plugin": {
+    "prefix": ["orion-plugin", "ecs-plugin"],
+    "body": [
+      "class ${1:PluginName} {",
+      "  constructor() {",
+      "    this.name = '${2:$1}';",
+      "    this.version = '${3:1.0.0}';",
+      "  }",
+      "",
+      "  install(context) {",
+      "    ${4:// Register components, systems, etc.}",
+      "  }",
+      "",
+      "  uninstall() {",
+      "    ${5:// Cleanup}",
+      "  }",
+      "}",
+      "",
+      "module.exports = { ${1:PluginName} };"
+    ],
+    "description": "Create an OrionECS plugin"
+  },
+  "Create Singleton": {
+    "prefix": ["orion-singleton", "ecs-singleton"],
+    "body": [
+      "// Define singleton component",
+      "class ${1:SingletonName} {",
+      "  constructor(${2:value} = ${3:0}) {",
+      "    this.${2:value} = ${2:value};",
+      "  }",
+      "}",
+      "",
+      "// Set singleton",
+      "engine.setSingleton(${1:SingletonName}, ${4:initialValue});",
+      "",
+      "// Access singleton",
+      "const ${5:singleton} = engine.getSingleton(${1:SingletonName});"
+    ],
+    "description": "Create and use an OrionECS singleton"
+  },
+  "Create Query": {
+    "prefix": ["orion-query", "ecs-query"],
+    "body": [
+      "const ${1:query} = engine.query()",
+      "  .withAll(${2:Component})",
+      "  .withNone(${3:ExcludedComponent})",
+      "  .withTags('${4:tag}')",
+      "  .build();",
+      "",
+      "for (const entity of ${1:query}) {",
+      "  const ${5:component} = entity.getComponent(${2:Component});",
+      "  ${6:// Process entity}",
+      "}"
+    ],
+    "description": "Create and iterate an OrionECS query"
+  },
+  "Command Buffer Spawn": {
+    "prefix": ["orion-spawn", "ecs-spawn"],
+    "body": [
+      "engine.commands.spawn()",
+      "  .named('${1:EntityName}')",
+      "  .with(${2:Component}, ${3:args})",
+      "  .with(${4:Component2}, ${5:args2});"
+    ],
+    "description": "Spawn entity using command buffer"
+  },
+  "Import OrionECS": {
+    "prefix": ["orion-import", "ecs-import"],
+    "body": [
+      "const { EngineBuilder, createTagComponent } = require('@orion-ecs/core');"
+    ],
+    "description": "Import OrionECS core"
+  },
+  "Transaction Block": {
+    "prefix": ["orion-transaction", "ecs-transaction"],
+    "body": [
+      "engine.beginTransaction();",
+      "",
+      "try {",
+      "  ${1:// Batch operations here}",
+      "  engine.commitTransaction();",
+      "} catch (error) {",
+      "  engine.rollbackTransaction();",
+      "  throw error;",
+      "}"
+    ],
+    "description": "Create a transaction block for batch operations"
+  },
+  "Message Bus": {
+    "prefix": ["orion-message", "ecs-message"],
+    "body": [
+      "// Publish message",
+      "engine.messageBus.publish('${1:channel}', { ${2:data}: ${3:value} }, '${4:SenderSystem}');",
+      "",
+      "// Subscribe to messages",
+      "engine.messageBus.subscribe('${1:channel}', (message) => {",
+      "  console.log('Received:', message.data);",
+      "});"
+    ],
+    "description": "Inter-system messaging with message bus"
+  },
+  "Debug Info": {
+    "prefix": ["orion-debug", "ecs-debug"],
+    "body": [
+      "const debugInfo = engine.getDebugInfo();",
+      "console.log('Entities:', debugInfo.entityCount);",
+      "console.log('Systems:', debugInfo.systemCount);",
+      "",
+      "const profiles = engine.getSystemProfiles();",
+      "console.table(profiles);",
+      "",
+      "const memStats = engine.getMemoryStats();",
+      "console.log('Memory:', memStats);"
+    ],
+    "description": "Get debug and profiling information"
+  }
+}

--- a/packages/vscode-extension/snippets/typescript.json
+++ b/packages/vscode-extension/snippets/typescript.json
@@ -1,0 +1,382 @@
+{
+  "Create Component": {
+    "prefix": ["orion-component", "ecs-component"],
+    "body": [
+      "export class ${1:ComponentName} {",
+      "  constructor(",
+      "    public ${2:property}: ${3:number} = ${4:0}",
+      "  ) {}",
+      "}"
+    ],
+    "description": "Create an OrionECS component class"
+  },
+  "Create Component with Multiple Properties": {
+    "prefix": ["orion-component-multi", "ecs-component-multi"],
+    "body": [
+      "export class ${1:ComponentName} {",
+      "  constructor(",
+      "    public ${2:x}: number = ${3:0},",
+      "    public ${4:y}: number = ${5:0}",
+      "  ) {}",
+      "}"
+    ],
+    "description": "Create an OrionECS component with multiple properties"
+  },
+  "Create Tag Component": {
+    "prefix": ["orion-tag", "ecs-tag"],
+    "body": [
+      "export const ${1:TagName} = createTagComponent('${2:$1}');"
+    ],
+    "description": "Create an OrionECS tag component"
+  },
+  "Create System": {
+    "prefix": ["orion-system", "ecs-system"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:Component}]",
+      "}, {",
+      "  priority: ${3:100},",
+      "  act: (entity, ${4:component}) => {",
+      "    ${5:// System logic}",
+      "  }",
+      "});"
+    ],
+    "description": "Create an OrionECS system"
+  },
+  "Create System with Hooks": {
+    "prefix": ["orion-system-hooks", "ecs-system-hooks"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:Component}]",
+      "}, {",
+      "  priority: ${3:100},",
+      "  before: () => {",
+      "    ${4:// Called before processing entities}",
+      "  },",
+      "  act: (entity, ${5:component}) => {",
+      "    ${6:// Process each entity}",
+      "  },",
+      "  after: () => {",
+      "    ${7:// Called after processing entities}",
+      "  }",
+      "});"
+    ],
+    "description": "Create an OrionECS system with lifecycle hooks"
+  },
+  "Create Fixed Update System": {
+    "prefix": ["orion-system-fixed", "ecs-system-fixed"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:Component}]",
+      "}, {",
+      "  priority: ${3:100},",
+      "  act: (entity, ${4:component}) => {",
+      "    ${5:// Fixed timestep logic}",
+      "  }",
+      "}, true);"
+    ],
+    "description": "Create an OrionECS fixed-update system"
+  },
+  "Create System with Complex Query": {
+    "prefix": ["orion-system-query", "ecs-system-query"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', {",
+      "  all: [${2:RequiredComponent}],",
+      "  any: [${3:OptionalComponent}],",
+      "  none: [${4:ExcludedComponent}],",
+      "  tags: ['${5:tag}']",
+      "}, {",
+      "  priority: ${6:100},",
+      "  act: (entity, ${7:required}) => {",
+      "    ${8:// System logic}",
+      "  }",
+      "});"
+    ],
+    "description": "Create an OrionECS system with complex query"
+  },
+  "Create Entity": {
+    "prefix": ["orion-entity", "ecs-entity"],
+    "body": [
+      "const ${1:entity} = engine.createEntity('${2:EntityName}');",
+      "${1:entity}.addComponent(${3:Component}, ${4:args});",
+      "${1:entity}.addTag('${5:tag}');"
+    ],
+    "description": "Create an OrionECS entity"
+  },
+  "Create Entity Prefab": {
+    "prefix": ["orion-prefab", "ecs-prefab"],
+    "body": [
+      "const ${1:prefabName}Prefab: EntityPrefab = {",
+      "  name: '${2:$1}',",
+      "  components: [",
+      "    { type: ${3:Component}, args: [${4:}] }",
+      "  ],",
+      "  tags: ['${5:tag}']",
+      "};",
+      "",
+      "engine.registerPrefab('${2:$1}', ${1:prefabName}Prefab);"
+    ],
+    "description": "Create and register an entity prefab"
+  },
+  "Create Engine": {
+    "prefix": ["orion-engine", "ecs-engine"],
+    "body": [
+      "const engine = new EngineBuilder()",
+      "  .withDebugMode(${1:true})",
+      "  .withFixedUpdateFPS(${2:60})",
+      "  .withArchetypes(${3:true})",
+      "  .build();",
+      "",
+      "engine.start();"
+    ],
+    "description": "Create and configure an OrionECS engine"
+  },
+  "Create Engine with Plugins": {
+    "prefix": ["orion-engine-plugins", "ecs-engine-plugins"],
+    "body": [
+      "const engine = new EngineBuilder()",
+      "  .withDebugMode(${1:true})",
+      "  .withFixedUpdateFPS(${2:60})",
+      "  .withArchetypes(${3:true})",
+      "  .use(new ${4:PluginName}())",
+      "  .build();",
+      "",
+      "engine.start();"
+    ],
+    "description": "Create an OrionECS engine with plugins"
+  },
+  "Game Loop": {
+    "prefix": ["orion-gameloop", "ecs-gameloop"],
+    "body": [
+      "let lastTime = 0;",
+      "",
+      "function gameLoop(timestamp: number) {",
+      "  const deltaTime = (timestamp - lastTime) / 1000;",
+      "  lastTime = timestamp;",
+      "",
+      "  engine.update(deltaTime);",
+      "",
+      "  requestAnimationFrame(gameLoop);",
+      "}",
+      "",
+      "requestAnimationFrame(gameLoop);"
+    ],
+    "description": "Create a game loop for OrionECS"
+  },
+  "Create Plugin": {
+    "prefix": ["orion-plugin", "ecs-plugin"],
+    "body": [
+      "import { EnginePlugin, PluginContext } from '@orion-ecs/plugin-api';",
+      "",
+      "export class ${1:PluginName} implements EnginePlugin {",
+      "  name = '${2:$1}';",
+      "  version = '${3:1.0.0}';",
+      "",
+      "  install(context: PluginContext): void {",
+      "    ${4:// Register components, systems, etc.}",
+      "  }",
+      "",
+      "  uninstall(): void {",
+      "    ${5:// Cleanup}",
+      "  }",
+      "}"
+    ],
+    "description": "Create an OrionECS plugin"
+  },
+  "Create Singleton": {
+    "prefix": ["orion-singleton", "ecs-singleton"],
+    "body": [
+      "// Define singleton component",
+      "class ${1:SingletonName} {",
+      "  constructor(",
+      "    public ${2:value}: ${3:number} = ${4:0}",
+      "  ) {}",
+      "}",
+      "",
+      "// Set singleton",
+      "engine.setSingleton(${1:SingletonName}, ${5:initialValue});",
+      "",
+      "// Access singleton",
+      "const ${6:singleton} = engine.getSingleton(${1:SingletonName});"
+    ],
+    "description": "Create and use an OrionECS singleton"
+  },
+  "Create Query": {
+    "prefix": ["orion-query", "ecs-query"],
+    "body": [
+      "const ${1:query} = engine.query()",
+      "  .withAll(${2:Component})",
+      "  .withNone(${3:ExcludedComponent})",
+      "  .withTags('${4:tag}')",
+      "  .build();",
+      "",
+      "for (const entity of ${1:query}) {",
+      "  const ${5:component} = entity.getComponent(${2:Component});",
+      "  ${6:// Process entity}",
+      "}"
+    ],
+    "description": "Create and iterate an OrionECS query"
+  },
+  "Command Buffer Spawn": {
+    "prefix": ["orion-spawn", "ecs-spawn"],
+    "body": [
+      "engine.commands.spawn()",
+      "  .named('${1:EntityName}')",
+      "  .with(${2:Component}, ${3:args})",
+      "  .with(${4:Component2}, ${5:args2});"
+    ],
+    "description": "Spawn entity using command buffer"
+  },
+  "Command Buffer Despawn": {
+    "prefix": ["orion-despawn", "ecs-despawn"],
+    "body": [
+      "engine.commands.despawn(${1:entity});"
+    ],
+    "description": "Despawn entity using command buffer"
+  },
+  "Component Validation": {
+    "prefix": ["orion-validator", "ecs-validator"],
+    "body": [
+      "engine.registerComponentValidator(${1:Component}, {",
+      "  validate: (component) => {",
+      "    if (${2:component.value < 0}) {",
+      "      return '${3:Error message}';",
+      "    }",
+      "    return true;",
+      "  },",
+      "  dependencies: [${4:DependentComponent}],",
+      "  conflicts: [${5:ConflictingComponent}]",
+      "});"
+    ],
+    "description": "Register component validator"
+  },
+  "Entity Hierarchy": {
+    "prefix": ["orion-hierarchy", "ecs-hierarchy"],
+    "body": [
+      "const ${1:parent} = engine.createEntity('${2:Parent}');",
+      "const ${3:child} = engine.createEntity('${4:Child}');",
+      "",
+      "${1:parent}.addChild(${3:child});",
+      "",
+      "// Or alternatively:",
+      "// ${3:child}.setParent(${1:parent});"
+    ],
+    "description": "Create entity hierarchy"
+  },
+  "System Singleton Watch": {
+    "prefix": ["orion-system-singleton", "ecs-system-singleton"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', { all: [] }, {",
+      "  watchSingletons: [${2:SingletonComponent}],",
+      "  onSingletonSet: (event) => {",
+      "    console.log('${2:SingletonComponent} set:', event.newValue);",
+      "  },",
+      "  onSingletonRemoved: (event) => {",
+      "    console.log('${2:SingletonComponent} removed');",
+      "  },",
+      "  act: () => {",
+      "    ${3:// System logic}",
+      "  }",
+      "});"
+    ],
+    "description": "Create system that watches singleton changes"
+  },
+  "System Hierarchy Watch": {
+    "prefix": ["orion-system-hierarchy", "ecs-system-hierarchy"],
+    "body": [
+      "engine.createSystem('${1:SystemName}', { all: [${2:Component}] }, {",
+      "  watchHierarchy: true,",
+      "  onChildAdded: (event) => {",
+      "    console.log('Child added:', event.child.name);",
+      "  },",
+      "  onChildRemoved: (event) => {",
+      "    console.log('Child removed:', event.child.name);",
+      "  },",
+      "  onParentChanged: (event) => {",
+      "    console.log('Parent changed:', event.previousParent?.name, '->', event.newParent?.name);",
+      "  },",
+      "  act: (entity, ${3:component}) => {",
+      "    ${4:// System logic}",
+      "  }",
+      "});"
+    ],
+    "description": "Create system that watches hierarchy changes"
+  },
+  "Import OrionECS": {
+    "prefix": ["orion-import", "ecs-import"],
+    "body": [
+      "import { EngineBuilder, Entity, EntityPrefab } from '@orion-ecs/core';"
+    ],
+    "description": "Import OrionECS core"
+  },
+  "Import OrionECS Full": {
+    "prefix": ["orion-import-full", "ecs-import-full"],
+    "body": [
+      "import {",
+      "  EngineBuilder,",
+      "  Entity,",
+      "  EntityPrefab,",
+      "  System,",
+      "  Query,",
+      "  createTagComponent",
+      "} from '@orion-ecs/core';"
+    ],
+    "description": "Import OrionECS with all common types"
+  },
+  "Transaction Block": {
+    "prefix": ["orion-transaction", "ecs-transaction"],
+    "body": [
+      "engine.beginTransaction();",
+      "",
+      "try {",
+      "  ${1:// Batch operations here}",
+      "  engine.commitTransaction();",
+      "} catch (error) {",
+      "  engine.rollbackTransaction();",
+      "  throw error;",
+      "}"
+    ],
+    "description": "Create a transaction block for batch operations"
+  },
+  "Message Bus": {
+    "prefix": ["orion-message", "ecs-message"],
+    "body": [
+      "// Publish message",
+      "engine.messageBus.publish('${1:channel}', { ${2:data}: ${3:value} }, '${4:SenderSystem}');",
+      "",
+      "// Subscribe to messages",
+      "engine.messageBus.subscribe('${1:channel}', (message) => {",
+      "  console.log('Received:', message.data);",
+      "});"
+    ],
+    "description": "Inter-system messaging with message bus"
+  },
+  "World Snapshot": {
+    "prefix": ["orion-snapshot", "ecs-snapshot"],
+    "body": [
+      "// Create snapshot",
+      "engine.createSnapshot();",
+      "",
+      "// ... game state changes ...",
+      "",
+      "// Restore snapshot",
+      "engine.restoreSnapshot();"
+    ],
+    "description": "Create and restore world snapshots"
+  },
+  "Debug Info": {
+    "prefix": ["orion-debug", "ecs-debug"],
+    "body": [
+      "const debugInfo = engine.getDebugInfo();",
+      "console.log('Entities:', debugInfo.entityCount);",
+      "console.log('Systems:', debugInfo.systemCount);",
+      "",
+      "const profiles = engine.getSystemProfiles();",
+      "console.table(profiles);",
+      "",
+      "const memStats = engine.getMemoryStats();",
+      "console.log('Memory:', memStats);"
+    ],
+    "description": "Get debug and profiling information"
+  }
+}

--- a/packages/vscode-extension/src/__tests__/__mocks__/vscode.ts
+++ b/packages/vscode-extension/src/__tests__/__mocks__/vscode.ts
@@ -1,0 +1,203 @@
+/**
+ * Mock for the vscode module for unit testing
+ */
+
+export const Uri = {
+    file: (path: string) => ({ fsPath: path, path, scheme: 'file' }),
+    parse: (str: string) => ({ toString: () => str }),
+};
+
+export const Range = class {
+    constructor(
+        public startLine: number,
+        public startChar: number,
+        public endLine: number,
+        public endChar: number
+    ) {}
+};
+
+export const Position = class {
+    constructor(
+        public line: number,
+        public character: number
+    ) {}
+};
+
+export const TreeItemCollapsibleState = {
+    None: 0,
+    Collapsed: 1,
+    Expanded: 2,
+};
+
+export const TreeItem = class {
+    label: string;
+    collapsibleState: number;
+    constructor(label: string, collapsibleState?: number) {
+        this.label = label;
+        this.collapsibleState = collapsibleState ?? 0;
+    }
+};
+
+export const ThemeIcon = class {
+    constructor(public id: string) {}
+};
+
+export const EventEmitter = class {
+    private listeners: ((...args: unknown[]) => void)[] = [];
+    event = (listener: (...args: unknown[]) => void) => {
+        this.listeners.push(listener);
+        return { dispose: () => {} };
+    };
+    fire = (data?: unknown) => {
+        for (const listener of this.listeners) {
+            listener(data);
+        }
+    };
+};
+
+export const CompletionItem = class {
+    label: string;
+    kind: number;
+    constructor(label: string, kind?: number) {
+        this.label = label;
+        this.kind = kind ?? 0;
+    }
+};
+
+export const CompletionItemKind = {
+    Text: 0,
+    Method: 1,
+    Function: 2,
+    Constructor: 3,
+    Field: 4,
+    Variable: 5,
+    Class: 6,
+    Interface: 7,
+    Module: 8,
+    Property: 9,
+    Unit: 10,
+    Value: 11,
+    Enum: 12,
+    Keyword: 13,
+    Snippet: 14,
+    Color: 15,
+    File: 16,
+    Reference: 17,
+    Folder: 18,
+    EnumMember: 19,
+    Constant: 20,
+    Struct: 21,
+    Event: 22,
+    Operator: 23,
+    TypeParameter: 24,
+};
+
+export const Hover = class {
+    contents: unknown;
+    range?: Range;
+    constructor(contents: unknown, range?: Range) {
+        this.contents = contents;
+        this.range = range;
+    }
+};
+
+export const MarkdownString = class {
+    value: string = '';
+    appendMarkdown(text: string) {
+        this.value += text;
+        return this;
+    }
+    appendCodeblock(code: string, language?: string) {
+        this.value += `\`\`\`${language || ''}\n${code}\n\`\`\`\n`;
+        return this;
+    }
+};
+
+export const CodeLens = class {
+    range: Range;
+    command: unknown;
+    constructor(range: Range, command?: unknown) {
+        this.range = range;
+        this.command = command;
+    }
+};
+
+export const SnippetString = class {
+    value: string;
+    constructor(value: string) {
+        this.value = value;
+    }
+};
+
+export const window = {
+    createOutputChannel: () => ({
+        appendLine: () => {},
+        dispose: () => {},
+    }),
+    showInformationMessage: async () => undefined,
+    showErrorMessage: async () => undefined,
+    showWarningMessage: async () => undefined,
+    showInputBox: async () => undefined,
+    showQuickPick: async () => undefined,
+    createWebviewPanel: () => ({
+        webview: { html: '' },
+        dispose: () => {},
+    }),
+    registerTreeDataProvider: () => ({ dispose: () => {} }),
+    activeTextEditor: undefined,
+};
+
+export const workspace = {
+    getConfiguration: () => ({
+        get: (key: string, defaultValue?: unknown) => defaultValue,
+    }),
+    findFiles: async () => [],
+    openTextDocument: async () => ({
+        getText: () => '',
+        lineAt: () => ({ text: '' }),
+    }),
+    createFileSystemWatcher: () => ({
+        onDidChange: () => ({ dispose: () => {} }),
+        onDidCreate: () => ({ dispose: () => {} }),
+        onDidDelete: () => ({ dispose: () => {} }),
+        dispose: () => {},
+    }),
+    onDidChangeConfiguration: () => ({ dispose: () => {} }),
+    onDidChangeTextDocument: () => ({ dispose: () => {} }),
+};
+
+export const languages = {
+    registerCodeLensProvider: () => ({ dispose: () => {} }),
+    registerCompletionItemProvider: () => ({ dispose: () => {} }),
+    registerHoverProvider: () => ({ dispose: () => {} }),
+};
+
+export const commands = {
+    registerCommand: () => ({ dispose: () => {} }),
+    executeCommand: async () => undefined,
+};
+
+export const env = {
+    openExternal: async () => true,
+};
+
+export default {
+    Uri,
+    Range,
+    Position,
+    TreeItemCollapsibleState,
+    TreeItem,
+    ThemeIcon,
+    EventEmitter,
+    CompletionItem,
+    CompletionItemKind,
+    Hover,
+    MarkdownString,
+    CodeLens,
+    SnippetString,
+    window,
+    workspace,
+    languages,
+    commands,
+    env,
+};

--- a/packages/vscode-extension/src/__tests__/ecsScanner.test.ts
+++ b/packages/vscode-extension/src/__tests__/ecsScanner.test.ts
@@ -1,0 +1,195 @@
+// Note: Since the scanner depends heavily on vscode.workspace APIs,
+// these tests verify the scanner's parsing logic with mocked workspace
+
+const isLikelyComponent = (className: string): boolean => {
+    const patterns = [
+        /System$/,
+        /Manager$/,
+        /Service$/,
+        /Controller$/,
+        /Provider$/,
+        /Factory$/,
+        /Builder$/,
+        /Handler$/,
+        /Plugin$/,
+    ];
+    return !patterns.some((p) => p.test(className));
+};
+
+describe('ECS Scanner', () => {
+    describe('Component Detection', () => {
+        it('should identify component class patterns', () => {
+            const componentPatterns = [
+                'class Position {',
+                'export class Velocity {',
+                'class Health extends Component {',
+            ];
+
+            for (const pattern of componentPatterns) {
+                const match = pattern.match(/^(?:export\s+)?class\s+(\w+)/);
+                expect(match).not.toBeNull();
+                expect(match?.[1]).toBeDefined();
+            }
+        });
+
+        it('should skip non-component class patterns', () => {
+            const nonComponentPatterns = [
+                'MovementSystem',
+                'EntityManager',
+                'GameService',
+                'PhysicsController',
+                'ComponentProvider',
+                'EntityFactory',
+                'EngineBuilder',
+                'InputHandler',
+                'PhysicsPlugin',
+            ];
+
+            for (const name of nonComponentPatterns) {
+                expect(isLikelyComponent(name)).toBe(false);
+            }
+        });
+
+        it('should identify likely component names', () => {
+            const componentNames = [
+                'Position',
+                'Velocity',
+                'Health',
+                'Transform',
+                'Sprite',
+                'RigidBody',
+            ];
+
+            for (const name of componentNames) {
+                expect(isLikelyComponent(name)).toBe(true);
+            }
+        });
+    });
+
+    describe('System Detection', () => {
+        it('should extract system name from createSystem call', () => {
+            const systemCalls = [
+                ".createSystem('Movement', {",
+                '.createSystem("Physics", {',
+                '.createSystem(`Render`, {',
+            ];
+
+            for (const call of systemCalls) {
+                const match = call.match(/\.createSystem\s*\(\s*['"`](\w+)['"`]/);
+                expect(match).not.toBeNull();
+                expect(match?.[1]).toBeDefined();
+            }
+        });
+
+        it('should extract query components from system definition', () => {
+            const systemDef = `
+        .createSystem('Movement', {
+          all: [Position, Velocity],
+          none: [Frozen]
+        }, {
+          priority: 100,
+          act: (entity, pos, vel) => {}
+        });
+      `;
+
+            const allMatch = systemDef.match(/all\s*:\s*\[([^\]]*)\]/);
+            expect(allMatch).not.toBeNull();
+
+            const components = allMatch?.[1].match(/\w+/g);
+            expect(components).toContain('Position');
+            expect(components).toContain('Velocity');
+        });
+
+        it('should detect fixed update systems', () => {
+            const variableSystem = ".createSystem('A', {}, {});";
+            const fixedSystem = ".createSystem('B', {}, {}, true);";
+
+            expect(variableSystem.includes(', true)')).toBe(false);
+            expect(fixedSystem.includes(', true)')).toBe(true);
+        });
+    });
+
+    describe('Prefab Detection', () => {
+        it('should extract prefab name from registerPrefab call', () => {
+            const prefabCalls = [".registerPrefab('Player', {", '.registerPrefab("Enemy", {'];
+
+            for (const call of prefabCalls) {
+                const match = call.match(/\.registerPrefab\s*\(\s*['"`](\w+)['"`]/);
+                expect(match).not.toBeNull();
+                expect(match?.[1]).toBeDefined();
+            }
+        });
+
+        it('should extract components from prefab definition', () => {
+            // Test the full prefab text with type extraction
+            const prefabDef = `
+        const playerPrefab = {
+          name: 'Player',
+          components: [
+            { type: Position, args: [0, 0] },
+            { type: Health, args: [100] }
+          ],
+          tags: ['player']
+        };
+      `;
+
+            // The scanner uses a different approach - it finds all type: X patterns
+            // in the entire prefab definition text
+            const typeMatches = prefabDef.match(/type\s*:\s*(\w+)/g);
+            expect(typeMatches).not.toBeNull();
+            expect(typeMatches).toHaveLength(2);
+
+            // Verify the component names can be extracted
+            const componentNames = typeMatches?.map((t) => t.replace(/type\s*:\s*/, ''));
+            expect(componentNames).toContain('Position');
+            expect(componentNames).toContain('Health');
+        });
+    });
+
+    describe('Tag Component Detection', () => {
+        it('should extract tag component names', () => {
+            const tagDefs = [
+                "const PlayerTag = createTagComponent('Player');",
+                "export const EnemyTag = createTagComponent('Enemy');",
+            ];
+
+            for (const def of tagDefs) {
+                const match = def.match(/createTagComponent\s*\(\s*['"`](\w+)['"`]\s*\)/);
+                expect(match).not.toBeNull();
+                expect(match?.[1]).toBeDefined();
+            }
+        });
+    });
+
+    describe('Property Extraction', () => {
+        it('should extract constructor properties with modifiers', () => {
+            const constructorLine = 'constructor(public x: number = 0, public y: number = 0) {}';
+
+            const matches = constructorLine.match(
+                /(?:public|private|protected|readonly)\s+(\w+)\s*(?::\s*(\w+(?:<[^>]+>)?))?\s*(?:=\s*([^,)]+))?/g
+            );
+
+            expect(matches).not.toBeNull();
+            expect(matches?.length).toBe(2);
+        });
+    });
+});
+
+describe('Snippet Validation', () => {
+    it('should have valid JSON in TypeScript snippets', () => {
+        // This test validates that the snippets file is valid JSON
+        // In a real test, we'd read the actual file
+        // Using string literal to avoid template placeholder warning
+        const bodyLine1 = 'class ' + '${1:Name}' + ' {';
+        const snippetStructure = {
+            prefix: ['orion-component'],
+            body: [bodyLine1, '}'],
+            description: 'Description',
+        };
+
+        expect(snippetStructure.prefix).toBeDefined();
+        expect(snippetStructure.body).toBeDefined();
+        expect(snippetStructure.description).toBeDefined();
+        expect(Array.isArray(snippetStructure.body)).toBe(true);
+    });
+});

--- a/packages/vscode-extension/src/commands/index.ts
+++ b/packages/vscode-extension/src/commands/index.ts
@@ -1,0 +1,415 @@
+import * as vscode from 'vscode';
+import type { ComponentsTreeProvider } from '../views/ComponentsTreeProvider';
+import type { EntitiesTreeProvider } from '../views/EntitiesTreeProvider';
+import type { SystemsTreeProvider } from '../views/SystemsTreeProvider';
+
+export interface CommandContext {
+    componentsProvider: ComponentsTreeProvider;
+    systemsProvider: SystemsTreeProvider;
+    entitiesProvider: EntitiesTreeProvider;
+    outputChannel: vscode.OutputChannel;
+}
+
+export function registerCommands(
+    context: vscode.ExtensionContext,
+    providers: CommandContext
+): void {
+    const { componentsProvider, systemsProvider, entitiesProvider, outputChannel } = providers;
+
+    // Create Component command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.createComponent', async () => {
+            const name = await vscode.window.showInputBox({
+                prompt: 'Enter component name',
+                placeHolder: 'Position',
+                validateInput: (value) => {
+                    if (!value) {
+                        return 'Component name is required';
+                    }
+                    if (!/^[A-Z][a-zA-Z0-9]*$/.test(value)) {
+                        return 'Component name must start with uppercase letter';
+                    }
+                    return null;
+                },
+            });
+
+            if (!name) {
+                return;
+            }
+
+            const properties = await vscode.window.showInputBox({
+                prompt: 'Enter properties (e.g., x: number = 0, y: number = 0)',
+                placeHolder: 'x: number = 0, y: number = 0',
+            });
+
+            const snippet = generateComponentSnippet(name, properties || '');
+            await insertSnippet(snippet);
+
+            outputChannel.appendLine(`Created component: ${name}`);
+        })
+    );
+
+    // Create System command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.createSystem', async () => {
+            const name = await vscode.window.showInputBox({
+                prompt: 'Enter system name',
+                placeHolder: 'MovementSystem',
+                validateInput: (value) => {
+                    if (!value) {
+                        return 'System name is required';
+                    }
+                    return null;
+                },
+            });
+
+            if (!name) {
+                return;
+            }
+
+            const components = await vscode.window.showInputBox({
+                prompt: 'Enter required components (comma-separated)',
+                placeHolder: 'Position, Velocity',
+            });
+
+            const priority = await vscode.window.showInputBox({
+                prompt: 'Enter priority (higher = runs first)',
+                placeHolder: '100',
+                value: '100',
+            });
+
+            const isFixed = await vscode.window.showQuickPick(['Variable', 'Fixed'], {
+                placeHolder: 'Update type',
+            });
+
+            const snippet = generateSystemSnippet(
+                name,
+                components || '',
+                priority || '100',
+                isFixed === 'Fixed'
+            );
+            await insertSnippet(snippet);
+
+            outputChannel.appendLine(`Created system: ${name}`);
+        })
+    );
+
+    // Create Prefab command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.createPrefab', async () => {
+            const name = await vscode.window.showInputBox({
+                prompt: 'Enter prefab name',
+                placeHolder: 'Player',
+                validateInput: (value) => {
+                    if (!value) {
+                        return 'Prefab name is required';
+                    }
+                    return null;
+                },
+            });
+
+            if (!name) {
+                return;
+            }
+
+            const components = await vscode.window.showInputBox({
+                prompt: 'Enter components (comma-separated)',
+                placeHolder: 'Position, Velocity, Health',
+            });
+
+            const tags = await vscode.window.showInputBox({
+                prompt: 'Enter tags (comma-separated)',
+                placeHolder: 'player, active',
+            });
+
+            const snippet = generatePrefabSnippet(name, components || '', tags || '');
+            await insertSnippet(snippet);
+
+            outputChannel.appendLine(`Created prefab: ${name}`);
+        })
+    );
+
+    // Show Entity Inspector command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.showEntityInspector', async () => {
+            const panel = vscode.window.createWebviewPanel(
+                'orionEntityInspector',
+                'Entity Inspector',
+                vscode.ViewColumn.Two,
+                { enableScripts: true }
+            );
+
+            panel.webview.html = getEntityInspectorHtml();
+            outputChannel.appendLine('Opened Entity Inspector');
+        })
+    );
+
+    // Show System Execution Order command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.showSystemExecutionOrder', async () => {
+            const panel = vscode.window.createWebviewPanel(
+                'orionSystemOrder',
+                'System Execution Order',
+                vscode.ViewColumn.Two,
+                { enableScripts: true }
+            );
+
+            panel.webview.html = getSystemExecutionOrderHtml();
+            outputChannel.appendLine('Opened System Execution Order view');
+        })
+    );
+
+    // Open Documentation command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.openDocumentation', async () => {
+            vscode.env.openExternal(vscode.Uri.parse('https://github.com/tyevco/OrionECS'));
+        })
+    );
+
+    // Refresh Entity Tree command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.refreshEntityTree', () => {
+            componentsProvider.refresh();
+            systemsProvider.refresh();
+            entitiesProvider.refresh();
+            outputChannel.appendLine('Refreshed all tree views');
+        })
+    );
+
+    // Find Component References command
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'orion-ecs.findComponentReferences',
+            async (componentName: string) => {
+                await vscode.commands.executeCommand('workbench.action.findInFiles', {
+                    query: componentName,
+                    triggerSearch: true,
+                    isRegex: false,
+                    isCaseSensitive: true,
+                    matchWholeWord: true,
+                });
+            }
+        )
+    );
+
+    // Show System Info command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.showSystemInfo', async (systemName: string) => {
+            vscode.window.showInformationMessage(`System: ${systemName}`);
+        })
+    );
+
+    // Show Prefab Info command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('orion-ecs.showPrefabInfo', async (prefabName: string) => {
+            vscode.window.showInformationMessage(`Prefab: ${prefabName}`);
+        })
+    );
+}
+
+function generateComponentSnippet(name: string, properties: string): string {
+    const props = properties
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p);
+
+    if (props.length === 0) {
+        return `export class ${name} {
+  constructor() {}
+}`;
+    }
+
+    const constructorParams = props.map((p) => `public ${p}`).join(',\n    ');
+
+    return `export class ${name} {
+  constructor(
+    ${constructorParams}
+  ) {}
+}`;
+}
+
+function generateSystemSnippet(
+    name: string,
+    components: string,
+    priority: string,
+    isFixed: boolean
+): string {
+    const componentList = components
+        .split(',')
+        .map((c) => c.trim())
+        .filter((c) => c);
+
+    const queryComponents =
+        componentList.length > 0 ? componentList.join(', ') : '/* Components */';
+
+    const paramNames = componentList.map((c) => c.toLowerCase()).join(', ');
+
+    return `engine.createSystem('${name}', {
+  all: [${queryComponents}]
+}, {
+  priority: ${priority},
+  act: (entity${paramNames ? `, ${paramNames}` : ''}) => {
+    // System logic here
+  }
+}${isFixed ? ', true' : ''});`;
+}
+
+function generatePrefabSnippet(name: string, components: string, tags: string): string {
+    const componentList = components
+        .split(',')
+        .map((c) => c.trim())
+        .filter((c) => c);
+    const tagList = tags
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t);
+
+    const componentEntries = componentList.map((c) => `    { type: ${c}, args: [] }`).join(',\n');
+
+    const tagEntries = tagList.map((t) => `'${t}'`).join(', ');
+
+    return `const ${name.toLowerCase()}Prefab: EntityPrefab = {
+  name: '${name}',
+  components: [
+${componentEntries || '    // Add components here'}
+  ],
+  tags: [${tagEntries || '/* Add tags here */'}]
+};
+
+engine.registerPrefab('${name}', ${name.toLowerCase()}Prefab);`;
+}
+
+async function insertSnippet(text: string): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+        const snippet = new vscode.SnippetString(text);
+        await editor.insertSnippet(snippet);
+    } else {
+        // Create a new untitled document
+        const doc = await vscode.workspace.openTextDocument({
+            language: 'typescript',
+            content: text,
+        });
+        await vscode.window.showTextDocument(doc);
+    }
+}
+
+function getEntityInspectorHtml(): string {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Entity Inspector</title>
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      color: var(--vscode-foreground);
+      background-color: var(--vscode-editor-background);
+      padding: 16px;
+    }
+    h1 { font-size: 1.5em; margin-bottom: 16px; }
+    .section { margin-bottom: 24px; }
+    .section-title {
+      font-weight: bold;
+      margin-bottom: 8px;
+      border-bottom: 1px solid var(--vscode-panel-border);
+      padding-bottom: 4px;
+    }
+    .placeholder {
+      color: var(--vscode-descriptionForeground);
+      font-style: italic;
+    }
+    .info-box {
+      background: var(--vscode-textBlockQuote-background);
+      padding: 12px;
+      border-radius: 4px;
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Entity Inspector</h1>
+
+  <div class="info-box">
+    <p>The Entity Inspector provides runtime debugging of your ECS world.</p>
+    <p>To use this feature, connect your running game to the extension via the OrionECS Debug API.</p>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Selected Entity</div>
+    <p class="placeholder">No entity selected</p>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Components</div>
+    <p class="placeholder">Select an entity to view its components</p>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Tags</div>
+    <p class="placeholder">No tags</p>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Hierarchy</div>
+    <p class="placeholder">No parent/children</p>
+  </div>
+</body>
+</html>`;
+}
+
+function getSystemExecutionOrderHtml(): string {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>System Execution Order</title>
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      color: var(--vscode-foreground);
+      background-color: var(--vscode-editor-background);
+      padding: 16px;
+    }
+    h1 { font-size: 1.5em; margin-bottom: 16px; }
+    .section { margin-bottom: 24px; }
+    .section-title {
+      font-weight: bold;
+      margin-bottom: 8px;
+      border-bottom: 1px solid var(--vscode-panel-border);
+      padding-bottom: 4px;
+    }
+    .placeholder {
+      color: var(--vscode-descriptionForeground);
+      font-style: italic;
+    }
+    .info-box {
+      background: var(--vscode-textBlockQuote-background);
+      padding: 12px;
+      border-radius: 4px;
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>System Execution Order</h1>
+
+  <div class="info-box">
+    <p>This view shows the order in which systems are executed during each engine update.</p>
+    <p>Systems are sorted by priority (higher priority runs first).</p>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Variable Update Systems</div>
+    <p class="placeholder">Scan your project to view systems</p>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Fixed Update Systems</div>
+    <p class="placeholder">Scan your project to view systems</p>
+  </div>
+</body>
+</html>`;
+}

--- a/packages/vscode-extension/src/providers/ComponentCodeLensProvider.ts
+++ b/packages/vscode-extension/src/providers/ComponentCodeLensProvider.ts
@@ -1,0 +1,185 @@
+import * as vscode from 'vscode';
+
+/**
+ * Provides CodeLens for component classes showing usage information
+ */
+export class ComponentCodeLensProvider implements vscode.CodeLensProvider {
+    private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+    private componentUsageCache: Map<string, { systemCount: number; entityCount: number }> =
+        new Map();
+
+    constructor() {
+        // Refresh CodeLenses when documents change
+        vscode.workspace.onDidChangeTextDocument(() => {
+            this._onDidChangeCodeLenses.fire();
+        });
+    }
+
+    async provideCodeLenses(
+        document: vscode.TextDocument,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.CodeLens[]> {
+        const config = vscode.workspace.getConfiguration('orion-ecs');
+        if (!config.get('enableCodeLens', true)) {
+            return [];
+        }
+
+        const codeLenses: vscode.CodeLens[] = [];
+        const text = document.getText();
+        const lines = text.split('\n');
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // Find component class definitions
+            const classMatch = line.match(/^(?:export\s+)?class\s+(\w+)/);
+            if (classMatch && this.isLikelyComponent(classMatch[1])) {
+                const range = new vscode.Range(i, 0, i, line.length);
+                const componentName = classMatch[1];
+
+                // Get usage info (async, but we'll use cached values)
+                const usage = await this.getComponentUsage(componentName);
+
+                codeLenses.push(
+                    new vscode.CodeLens(range, {
+                        title: `$(symbol-class) ${usage.systemCount} systems | $(pulse) ${usage.entityCount} prefabs`,
+                        command: 'orion-ecs.findComponentReferences',
+                        arguments: [componentName],
+                        tooltip: `Click to find all references to ${componentName}`,
+                    })
+                );
+            }
+
+            // Find system definitions
+            if (line.includes('.createSystem')) {
+                const systemMatch = line.match(/\.createSystem\s*\(\s*['"`](\w+)['"`]/);
+                if (systemMatch) {
+                    const range = new vscode.Range(i, 0, i, line.length);
+                    const systemName = systemMatch[1];
+
+                    codeLenses.push(
+                        new vscode.CodeLens(range, {
+                            title: '$(symbol-method) System',
+                            command: 'orion-ecs.showSystemInfo',
+                            arguments: [systemName],
+                            tooltip: `View details for ${systemName}`,
+                        })
+                    );
+                }
+            }
+
+            // Find prefab definitions
+            if (line.includes('.registerPrefab')) {
+                const prefabMatch = line.match(/\.registerPrefab\s*\(\s*['"`](\w+)['"`]/);
+                if (prefabMatch) {
+                    const range = new vscode.Range(i, 0, i, line.length);
+                    const prefabName = prefabMatch[1];
+
+                    codeLenses.push(
+                        new vscode.CodeLens(range, {
+                            title: '$(package) Prefab',
+                            command: 'orion-ecs.showPrefabInfo',
+                            arguments: [prefabName],
+                            tooltip: `View details for ${prefabName}`,
+                        })
+                    );
+                }
+            }
+        }
+
+        return codeLenses;
+    }
+
+    resolveCodeLens(codeLens: vscode.CodeLens, _token: vscode.CancellationToken): vscode.CodeLens {
+        return codeLens;
+    }
+
+    /**
+     * Gets the usage count for a component across systems and prefabs
+     */
+    private async getComponentUsage(
+        componentName: string
+    ): Promise<{ systemCount: number; entityCount: number }> {
+        // Check cache first
+        const cached = this.componentUsageCache.get(componentName);
+        if (cached) {
+            return cached;
+        }
+
+        let systemCount = 0;
+        let entityCount = 0;
+
+        try {
+            const files = await vscode.workspace.findFiles('**/*.{ts,js}', '**/node_modules/**');
+
+            for (const file of files) {
+                try {
+                    const document = await vscode.workspace.openTextDocument(file);
+                    const text = document.getText();
+
+                    // Count systems using this component
+                    const systemMatches = text.match(
+                        new RegExp(
+                            `\\.createSystem\\s*\\([^)]*all\\s*:\\s*\\[[^\\]]*${componentName}[^\\]]*\\]`,
+                            'g'
+                        )
+                    );
+                    if (systemMatches) {
+                        systemCount += systemMatches.length;
+                    }
+
+                    // Count prefabs using this component
+                    const prefabMatches = text.match(
+                        new RegExp(`type\\s*:\\s*${componentName}`, 'g')
+                    );
+                    if (prefabMatches) {
+                        entityCount += prefabMatches.length;
+                    }
+                } catch {
+                    // Skip unreadable files
+                }
+            }
+        } catch {
+            // Return zeros on error
+        }
+
+        const result = { systemCount, entityCount };
+        this.componentUsageCache.set(componentName, result);
+
+        // Clear cache after 30 seconds
+        setTimeout(() => {
+            this.componentUsageCache.delete(componentName);
+        }, 30000);
+
+        return result;
+    }
+
+    /**
+     * Determines if a class name is likely a component
+     */
+    private isLikelyComponent(className: string): boolean {
+        const nonComponentPatterns = [
+            /System$/,
+            /Manager$/,
+            /Service$/,
+            /Controller$/,
+            /Provider$/,
+            /Factory$/,
+            /Builder$/,
+            /Handler$/,
+            /Plugin$/,
+            /Engine$/,
+            /Query$/,
+        ];
+
+        for (const pattern of nonComponentPatterns) {
+            if (pattern.test(className)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/packages/vscode-extension/src/providers/ECSCompletionProvider.ts
+++ b/packages/vscode-extension/src/providers/ECSCompletionProvider.ts
@@ -1,0 +1,350 @@
+import * as vscode from 'vscode';
+import { scanForComponents, scanForSystems } from '../utils/ecsScanner';
+
+/**
+ * Provides intelligent code completion for ECS patterns
+ */
+export class ECSCompletionProvider implements vscode.CompletionItemProvider {
+    private componentCache: string[] = [];
+    private systemCache: string[] = [];
+    private lastCacheUpdate = 0;
+    private readonly CACHE_TTL = 30000; // 30 seconds
+
+    async provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _token: vscode.CancellationToken,
+        _context: vscode.CompletionContext
+    ): Promise<vscode.CompletionItem[] | vscode.CompletionList | undefined> {
+        const linePrefix = document.lineAt(position).text.slice(0, position.character);
+
+        // Refresh cache if needed
+        await this.refreshCacheIfNeeded();
+
+        const items: vscode.CompletionItem[] = [];
+
+        // Completion for query component arrays: all: [|], any: [|], none: [|]
+        if (this.isInQueryArray(linePrefix)) {
+            items.push(...this.getComponentCompletions());
+        }
+
+        // Completion for addComponent, getComponent, hasComponent, removeComponent
+        if (this.isInComponentMethod(linePrefix)) {
+            items.push(...this.getComponentCompletions());
+        }
+
+        // Completion for getSystem
+        if (this.isInGetSystem(linePrefix)) {
+            items.push(...this.getSystemCompletions());
+        }
+
+        // Completion for entity methods
+        if (this.isInEntityMethod(linePrefix)) {
+            items.push(...this.getEntityMethodCompletions());
+        }
+
+        // Completion for engine methods
+        if (this.isInEngineMethod(linePrefix)) {
+            items.push(...this.getEngineMethodCompletions());
+        }
+
+        // Completion for tags
+        if (this.isInTagContext(linePrefix)) {
+            items.push(...this.getCommonTagCompletions());
+        }
+
+        return items;
+    }
+
+    private async refreshCacheIfNeeded(): Promise<void> {
+        const now = Date.now();
+        if (now - this.lastCacheUpdate > this.CACHE_TTL) {
+            const components = await scanForComponents();
+            this.componentCache = components.map((c) => c.name);
+
+            const systems = await scanForSystems();
+            this.systemCache = systems.map((s) => s.name);
+
+            this.lastCacheUpdate = now;
+        }
+    }
+
+    private isInQueryArray(linePrefix: string): boolean {
+        // Match patterns like: all: [, any: [, none: [
+        return /(?:all|any|none)\s*:\s*\[[^\]]*$/.test(linePrefix);
+    }
+
+    private isInComponentMethod(linePrefix: string): boolean {
+        // Match patterns like: .addComponent(, .getComponent(, etc.
+        return /\.(addComponent|getComponent|hasComponent|removeComponent)\s*\(\s*$/.test(
+            linePrefix
+        );
+    }
+
+    private isInGetSystem(linePrefix: string): boolean {
+        return /\.getSystem\s*\(\s*['"`]?$/.test(linePrefix);
+    }
+
+    private isInEntityMethod(linePrefix: string): boolean {
+        return /entity\.\s*$/.test(linePrefix);
+    }
+
+    private isInEngineMethod(linePrefix: string): boolean {
+        return /engine\.\s*$/.test(linePrefix);
+    }
+
+    private isInTagContext(linePrefix: string): boolean {
+        // Match patterns like: .addTag(', tags: [', .hasTag('
+        return /(?:\.addTag|\.hasTag|\.removeTag|tags\s*:\s*\[)\s*\(\s*['"`]?$/.test(linePrefix);
+    }
+
+    private getComponentCompletions(): vscode.CompletionItem[] {
+        return this.componentCache.map((name) => {
+            const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Class);
+            item.detail = 'Component';
+            item.documentation = new vscode.MarkdownString(`Component class \`${name}\``);
+            item.sortText = '0' + name; // Prioritize components
+            return item;
+        });
+    }
+
+    private getSystemCompletions(): vscode.CompletionItem[] {
+        return this.systemCache.map((name) => {
+            const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Method);
+            item.detail = 'System';
+            item.documentation = new vscode.MarkdownString(`System \`${name}\``);
+            item.insertText = `'${name}'`;
+            return item;
+        });
+    }
+
+    private getEntityMethodCompletions(): vscode.CompletionItem[] {
+        const methods = [
+            {
+                name: 'addComponent',
+                signature: '(Component, ...args)',
+                doc: 'Add a component to this entity',
+            },
+            {
+                name: 'getComponent',
+                signature: '(Component)',
+                doc: 'Get a component from this entity',
+            },
+            {
+                name: 'hasComponent',
+                signature: '(Component)',
+                doc: 'Check if entity has a component',
+            },
+            {
+                name: 'removeComponent',
+                signature: '(Component)',
+                doc: 'Remove a component from this entity',
+            },
+            {
+                name: 'addTag',
+                signature: '(tag: string)',
+                doc: 'Add a tag to this entity',
+            },
+            {
+                name: 'hasTag',
+                signature: '(tag: string)',
+                doc: 'Check if entity has a tag',
+            },
+            {
+                name: 'removeTag',
+                signature: '(tag: string)',
+                doc: 'Remove a tag from this entity',
+            },
+            { name: 'queueFree', signature: '()', doc: 'Mark entity for deletion' },
+            {
+                name: 'setParent',
+                signature: '(parent: Entity | null)',
+                doc: 'Set the parent entity',
+            },
+            {
+                name: 'addChild',
+                signature: '(child: Entity)',
+                doc: 'Add a child entity',
+            },
+            {
+                name: 'removeChild',
+                signature: '(child: Entity)',
+                doc: 'Remove a child entity',
+            },
+            {
+                name: 'getChildren',
+                signature: '()',
+                doc: 'Get all child entities',
+            },
+            { name: 'getParent', signature: '()', doc: 'Get the parent entity' },
+            {
+                name: 'getDescendants',
+                signature: '(maxDepth?)',
+                doc: 'Get all descendants',
+            },
+            { name: 'getAncestors', signature: '()', doc: 'Get all ancestors' },
+            { name: 'getRoot', signature: '()', doc: 'Get the root entity' },
+            { name: 'getDepth', signature: '()', doc: 'Get hierarchy depth' },
+            { name: 'getSiblings', signature: '()', doc: 'Get sibling entities' },
+        ];
+
+        return methods.map((m) => {
+            const item = new vscode.CompletionItem(m.name, vscode.CompletionItemKind.Method);
+            item.detail = m.signature;
+            item.documentation = new vscode.MarkdownString(m.doc);
+            return item;
+        });
+    }
+
+    private getEngineMethodCompletions(): vscode.CompletionItem[] {
+        const methods = [
+            {
+                name: 'createEntity',
+                signature: '(name?: string)',
+                doc: 'Create a new entity',
+            },
+            {
+                name: 'createEntities',
+                signature: '(count, prefab?)',
+                doc: 'Create multiple entities',
+            },
+            {
+                name: 'createFromPrefab',
+                signature: '(prefabName, entityName?)',
+                doc: 'Create entity from prefab',
+            },
+            {
+                name: 'createSystem',
+                signature: '(name, query, options, fixed?)',
+                doc: 'Create a new system',
+            },
+            {
+                name: 'registerPrefab',
+                signature: '(name, prefab)',
+                doc: 'Register an entity prefab',
+            },
+            {
+                name: 'getEntity',
+                signature: '(id)',
+                doc: 'Get entity by ID',
+            },
+            {
+                name: 'getEntityByName',
+                signature: '(name)',
+                doc: 'Get entity by name',
+            },
+            {
+                name: 'getSystem',
+                signature: '(name)',
+                doc: 'Get system by name',
+            },
+            {
+                name: 'getAllSystems',
+                signature: '()',
+                doc: 'Get all registered systems',
+            },
+            {
+                name: 'removeSystem',
+                signature: '(name)',
+                doc: 'Remove a system',
+            },
+            { name: 'update', signature: '(deltaTime)', doc: 'Run one update cycle' },
+            { name: 'start', signature: '()', doc: 'Start the engine' },
+            { name: 'stop', signature: '()', doc: 'Stop the engine' },
+            { name: 'destroy', signature: '()', doc: 'Destroy the engine' },
+            {
+                name: 'setSingleton',
+                signature: '(Component, ...args)',
+                doc: 'Set a singleton component',
+            },
+            {
+                name: 'getSingleton',
+                signature: '(Component)',
+                doc: 'Get a singleton component',
+            },
+            {
+                name: 'hasSingleton',
+                signature: '(Component)',
+                doc: 'Check if singleton exists',
+            },
+            {
+                name: 'removeSingleton',
+                signature: '(Component)',
+                doc: 'Remove a singleton',
+            },
+            {
+                name: 'createSnapshot',
+                signature: '()',
+                doc: 'Create world state snapshot',
+            },
+            {
+                name: 'restoreSnapshot',
+                signature: '()',
+                doc: 'Restore world state',
+            },
+            {
+                name: 'beginTransaction',
+                signature: '()',
+                doc: 'Begin batch transaction',
+            },
+            {
+                name: 'commitTransaction',
+                signature: '()',
+                doc: 'Commit batch transaction',
+            },
+            {
+                name: 'query',
+                signature: '()',
+                doc: 'Create a fluent query builder',
+            },
+            {
+                name: 'getDebugInfo',
+                signature: '()',
+                doc: 'Get debug information',
+            },
+            {
+                name: 'getMemoryStats',
+                signature: '()',
+                doc: 'Get memory statistics',
+            },
+            {
+                name: 'getSystemProfiles',
+                signature: '()',
+                doc: 'Get system profiling data',
+            },
+        ];
+
+        return methods.map((m) => {
+            const item = new vscode.CompletionItem(m.name, vscode.CompletionItemKind.Method);
+            item.detail = m.signature;
+            item.documentation = new vscode.MarkdownString(m.doc);
+            return item;
+        });
+    }
+
+    private getCommonTagCompletions(): vscode.CompletionItem[] {
+        const commonTags = [
+            'player',
+            'enemy',
+            'active',
+            'inactive',
+            'visible',
+            'hidden',
+            'solid',
+            'trigger',
+            'interactive',
+            'static',
+            'dynamic',
+            'ui',
+            'world',
+            'debug',
+        ];
+
+        return commonTags.map((tag) => {
+            const item = new vscode.CompletionItem(tag, vscode.CompletionItemKind.Constant);
+            item.detail = 'Common tag';
+            item.insertText = `'${tag}'`;
+            return item;
+        });
+    }
+}

--- a/packages/vscode-extension/src/providers/ECSHoverProvider.ts
+++ b/packages/vscode-extension/src/providers/ECSHoverProvider.ts
@@ -1,0 +1,318 @@
+import * as vscode from 'vscode';
+
+/**
+ * Provides hover documentation for ECS patterns and APIs
+ */
+export class ECSHoverProvider implements vscode.HoverProvider {
+    private readonly apiDocs: Map<string, ApiDocumentation> = new Map();
+
+    constructor() {
+        this.initializeApiDocs();
+    }
+
+    provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _token: vscode.CancellationToken
+    ): vscode.Hover | undefined {
+        const wordRange = document.getWordRangeAtPosition(position);
+        if (!wordRange) {
+            return undefined;
+        }
+
+        const word = document.getText(wordRange);
+        const lineText = document.lineAt(position).text;
+
+        // Check for ECS API methods
+        const apiDoc = this.apiDocs.get(word);
+        if (apiDoc && this.isInEcsContext(lineText)) {
+            return new vscode.Hover(this.formatApiDoc(apiDoc), wordRange);
+        }
+
+        // Check for ECS patterns
+        const patternDoc = this.getPatternDocumentation(word, lineText);
+        if (patternDoc) {
+            return new vscode.Hover(patternDoc, wordRange);
+        }
+
+        return undefined;
+    }
+
+    private isInEcsContext(lineText: string): boolean {
+        return (
+            lineText.includes('engine.') ||
+            lineText.includes('entity.') ||
+            lineText.includes('createSystem') ||
+            lineText.includes('createEntity') ||
+            lineText.includes('EngineBuilder')
+        );
+    }
+
+    private formatApiDoc(doc: ApiDocumentation): vscode.MarkdownString {
+        const md = new vscode.MarkdownString();
+        md.appendCodeblock(doc.signature, 'typescript');
+        md.appendMarkdown(`\n\n${doc.description}\n\n`);
+
+        if (doc.parameters && doc.parameters.length > 0) {
+            md.appendMarkdown('**Parameters:**\n');
+            for (const param of doc.parameters) {
+                md.appendMarkdown(`- \`${param.name}\`: ${param.description}\n`);
+            }
+            md.appendMarkdown('\n');
+        }
+
+        if (doc.returns) {
+            md.appendMarkdown(`**Returns:** ${doc.returns}\n\n`);
+        }
+
+        if (doc.example) {
+            md.appendMarkdown('**Example:**\n');
+            md.appendCodeblock(doc.example, 'typescript');
+        }
+
+        return md;
+    }
+
+    private getPatternDocumentation(
+        word: string,
+        lineText: string
+    ): vscode.MarkdownString | undefined {
+        // Query patterns
+        if (word === 'all' && lineText.includes(':')) {
+            return this.createMarkdown(
+                '**ALL Query**',
+                'Matches entities that have ALL of the specified components.',
+                '{ all: [Position, Velocity] }'
+            );
+        }
+
+        if (word === 'any' && lineText.includes(':')) {
+            return this.createMarkdown(
+                '**ANY Query**',
+                'Matches entities that have ANY of the specified components.',
+                '{ any: [Flying, Swimming] }'
+            );
+        }
+
+        if (word === 'none' && lineText.includes(':')) {
+            return this.createMarkdown(
+                '**NONE Query**',
+                'Matches entities that do NOT have any of the specified components.',
+                '{ none: [Frozen, Dead] }'
+            );
+        }
+
+        // System options
+        if (word === 'priority') {
+            return this.createMarkdown(
+                '**System Priority**',
+                'Higher priority systems execute first. Default is 0.',
+                '{ priority: 100 }'
+            );
+        }
+
+        if (word === 'act') {
+            return this.createMarkdown(
+                '**System Action**',
+                'The main function that processes each entity matching the query.',
+                'act: (entity, position, velocity) => {\n  position.x += velocity.x;\n}'
+            );
+        }
+
+        if (word === 'before') {
+            return this.createMarkdown(
+                '**Before Hook**',
+                'Called once before the system processes any entities.',
+                "before: () => {\n  console.log('Starting system');\n}"
+            );
+        }
+
+        if (word === 'after') {
+            return this.createMarkdown(
+                '**After Hook**',
+                'Called once after the system has processed all entities.',
+                "after: () => {\n  console.log('System complete');\n}"
+            );
+        }
+
+        return undefined;
+    }
+
+    private createMarkdown(
+        title: string,
+        description: string,
+        example: string
+    ): vscode.MarkdownString {
+        const md = new vscode.MarkdownString();
+        md.appendMarkdown(`${title}\n\n${description}\n\n`);
+        md.appendMarkdown('**Example:**\n');
+        md.appendCodeblock(example, 'typescript');
+        return md;
+    }
+
+    private initializeApiDocs(): void {
+        // Entity methods
+        this.apiDocs.set('addComponent', {
+            signature:
+                'entity.addComponent<T>(Component: ComponentClass<T>, ...args: any[]): Entity',
+            description: 'Adds a component to this entity.',
+            parameters: [
+                { name: 'Component', description: 'The component class to add' },
+                {
+                    name: '...args',
+                    description: 'Arguments passed to the component constructor',
+                },
+            ],
+            returns: 'The entity (for chaining)',
+            example:
+                'entity.addComponent(Position, 100, 200);\nentity.addComponent(Velocity, 5, 0);',
+        });
+
+        this.apiDocs.set('getComponent', {
+            signature: 'entity.getComponent<T>(Component: ComponentClass<T>): T | undefined',
+            description: 'Gets a component from this entity.',
+            parameters: [{ name: 'Component', description: 'The component class to retrieve' }],
+            returns: 'The component instance or undefined if not found',
+            example: 'const pos = entity.getComponent(Position);\nif (pos) {\n  pos.x += 10;\n}',
+        });
+
+        this.apiDocs.set('hasComponent', {
+            signature: 'entity.hasComponent(Component: ComponentClass<any>): boolean',
+            description: 'Checks if this entity has a specific component.',
+            parameters: [{ name: 'Component', description: 'The component class to check for' }],
+            returns: 'True if the entity has the component',
+            example: 'if (entity.hasComponent(Health)) {\n  // Entity can take damage\n}',
+        });
+
+        this.apiDocs.set('removeComponent', {
+            signature: 'entity.removeComponent(Component: ComponentClass<any>): Entity',
+            description: 'Removes a component from this entity.',
+            parameters: [{ name: 'Component', description: 'The component class to remove' }],
+            returns: 'The entity (for chaining)',
+            example: 'entity.removeComponent(Frozen);',
+        });
+
+        this.apiDocs.set('queueFree', {
+            signature: 'entity.queueFree(): void',
+            description:
+                'Marks this entity for deletion. The entity will be removed after the current frame completes.',
+            returns: 'void',
+            example: 'if (health.current <= 0) {\n  entity.queueFree();\n}',
+        });
+
+        this.apiDocs.set('addTag', {
+            signature: 'entity.addTag(tag: string): Entity',
+            description: 'Adds a tag to this entity.',
+            parameters: [{ name: 'tag', description: 'The tag string to add' }],
+            returns: 'The entity (for chaining)',
+            example: "entity.addTag('player').addTag('active');",
+        });
+
+        this.apiDocs.set('hasTag', {
+            signature: 'entity.hasTag(tag: string): boolean',
+            description: 'Checks if this entity has a specific tag.',
+            parameters: [{ name: 'tag', description: 'The tag to check for' }],
+            returns: 'True if the entity has the tag',
+            example: "if (entity.hasTag('enemy')) {\n  // Handle enemy\n}",
+        });
+
+        // Engine methods
+        this.apiDocs.set('createEntity', {
+            signature: 'engine.createEntity(name?: string): Entity',
+            description: 'Creates a new entity.',
+            parameters: [
+                {
+                    name: 'name',
+                    description: 'Optional name for the entity (for debugging)',
+                },
+            ],
+            returns: 'The newly created entity',
+            example:
+                "const player = engine.createEntity('Player');\nplayer.addComponent(Position, 0, 0);",
+        });
+
+        this.apiDocs.set('createSystem', {
+            signature:
+                'engine.createSystem(name: string, query: QueryDef, options: SystemOptions, fixed?: boolean): System',
+            description: 'Creates and registers a new system.',
+            parameters: [
+                { name: 'name', description: 'Unique name for the system' },
+                {
+                    name: 'query',
+                    description: 'Query defining which entities this system processes',
+                },
+                {
+                    name: 'options',
+                    description: 'System options including act, before, after, priority',
+                },
+                {
+                    name: 'fixed',
+                    description:
+                        'If true, runs at fixed timestep (default: false, variable update)',
+                },
+            ],
+            returns: 'The created system',
+            example:
+                "engine.createSystem('Movement', {\n  all: [Position, Velocity]\n}, {\n  priority: 100,\n  act: (entity, pos, vel) => {\n    pos.x += vel.x;\n    pos.y += vel.y;\n  }\n});",
+        });
+
+        this.apiDocs.set('update', {
+            signature: 'engine.update(deltaTime: number): void',
+            description: 'Runs one update cycle of all systems. Call this in your game loop.',
+            parameters: [
+                {
+                    name: 'deltaTime',
+                    description: 'Time elapsed since last update (in seconds)',
+                },
+            ],
+            returns: 'void',
+            example:
+                'function gameLoop(timestamp: number) {\n  const delta = (timestamp - lastTime) / 1000;\n  engine.update(delta);\n  lastTime = timestamp;\n  requestAnimationFrame(gameLoop);\n}',
+        });
+
+        this.apiDocs.set('setSingleton', {
+            signature: 'engine.setSingleton<T>(Component: ComponentClass<T>, ...args: any[]): T',
+            description:
+                'Sets a singleton component. Singletons are global state not tied to entities.',
+            parameters: [
+                { name: 'Component', description: 'The singleton component class' },
+                {
+                    name: '...args',
+                    description: 'Arguments passed to the component constructor',
+                },
+            ],
+            returns: 'The singleton instance',
+            example:
+                'engine.setSingleton(GameTime, 0, 0);\n\nconst time = engine.getSingleton(GameTime);\ntime.elapsed += deltaTime;',
+        });
+
+        this.apiDocs.set('createFromPrefab', {
+            signature: 'engine.createFromPrefab(prefabName: string, entityName?: string): Entity',
+            description: 'Creates an entity from a registered prefab template.',
+            parameters: [
+                { name: 'prefabName', description: 'Name of the registered prefab' },
+                { name: 'entityName', description: 'Optional name for the new entity' },
+            ],
+            returns: 'The newly created entity with prefab components',
+            example:
+                "engine.registerPrefab('Enemy', enemyPrefab);\nconst enemy = engine.createFromPrefab('Enemy', 'Enemy1');",
+        });
+
+        // EngineBuilder methods
+        this.apiDocs.set('EngineBuilder', {
+            signature: 'new EngineBuilder()',
+            description: 'Fluent builder for configuring and creating an Engine instance.',
+            returns: 'An EngineBuilder instance',
+            example:
+                'const engine = new EngineBuilder()\n  .withDebugMode(true)\n  .withFixedUpdateFPS(60)\n  .withArchetypes(true)\n  .build();',
+        });
+    }
+}
+
+interface ApiDocumentation {
+    signature: string;
+    description: string;
+    parameters?: { name: string; description: string }[];
+    returns?: string;
+    example?: string;
+}

--- a/packages/vscode-extension/src/utils/ecsScanner.ts
+++ b/packages/vscode-extension/src/utils/ecsScanner.ts
@@ -1,0 +1,523 @@
+import * as vscode from 'vscode';
+
+export interface ComponentInfo {
+    name: string;
+    filePath: string;
+    line: number;
+    properties: PropertyInfo[];
+    isTagComponent: boolean;
+}
+
+export interface PropertyInfo {
+    name: string;
+    type: string;
+    defaultValue?: string;
+}
+
+export interface SystemInfo {
+    name: string;
+    filePath: string;
+    line: number;
+    queryComponents: string[];
+    priority?: number;
+    isFixedUpdate: boolean;
+    tags: string[];
+}
+
+export interface PrefabInfo {
+    name: string;
+    filePath: string;
+    line: number;
+    components: string[];
+    tags: string[];
+}
+
+/**
+ * Scans the workspace for ECS components
+ */
+export async function scanForComponents(): Promise<ComponentInfo[]> {
+    const components: ComponentInfo[] = [];
+
+    try {
+        const files = await vscode.workspace.findFiles('**/*.{ts,js}', '**/node_modules/**');
+
+        for (const file of files) {
+            try {
+                const document = await vscode.workspace.openTextDocument(file);
+                const text = document.getText();
+
+                // Find class definitions that look like components
+                const classMatches = findComponentClasses(text, file.fsPath);
+                components.push(...classMatches);
+
+                // Find tag components
+                const tagMatches = findTagComponents(text, file.fsPath);
+                components.push(...tagMatches);
+            } catch {
+                // Skip files that can't be read
+            }
+        }
+    } catch {
+        // Return empty if workspace scan fails
+    }
+
+    return components;
+}
+
+/**
+ * Finds component class definitions in text
+ */
+function findComponentClasses(text: string, filePath: string): ComponentInfo[] {
+    const components: ComponentInfo[] = [];
+    const lines = text.split('\n');
+
+    // Look for class definitions that appear to be components
+    // Heuristic: classes with constructor parameters or simple data properties
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const match = line.match(/^(?:export\s+)?class\s+(\w+)/);
+
+        if (match) {
+            const className = match[1];
+
+            // Skip common non-component class names
+            if (isLikelyComponent(className)) {
+                const properties = extractProperties(lines, i);
+
+                components.push({
+                    name: className,
+                    filePath,
+                    line: i + 1,
+                    properties,
+                    isTagComponent: false,
+                });
+            }
+        }
+    }
+
+    return components;
+}
+
+/**
+ * Finds tag component definitions in text
+ */
+function findTagComponents(text: string, filePath: string): ComponentInfo[] {
+    const components: ComponentInfo[] = [];
+    const lines = text.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const match = line.match(/createTagComponent\s*\(\s*['"`](\w+)['"`]\s*\)/);
+
+        if (match) {
+            components.push({
+                name: match[1],
+                filePath,
+                line: i + 1,
+                properties: [],
+                isTagComponent: true,
+            });
+        }
+    }
+
+    return components;
+}
+
+/**
+ * Determines if a class name is likely a component
+ */
+function isLikelyComponent(className: string): boolean {
+    // Skip common non-component patterns
+    const nonComponentPatterns = [
+        /System$/,
+        /Manager$/,
+        /Service$/,
+        /Controller$/,
+        /Provider$/,
+        /Factory$/,
+        /Builder$/,
+        /Handler$/,
+        /Plugin$/,
+        /Engine$/,
+        /Query$/,
+    ];
+
+    for (const pattern of nonComponentPatterns) {
+        if (pattern.test(className)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Extracts properties from a class definition
+ */
+function extractProperties(lines: string[], classLineIndex: number): PropertyInfo[] {
+    const properties: PropertyInfo[] = [];
+    let braceCount = 0;
+    let inConstructor = false;
+    let foundOpenBrace = false;
+
+    for (let i = classLineIndex; i < lines.length && i < classLineIndex + 50; i++) {
+        const line = lines[i];
+
+        // Count braces
+        for (const char of line) {
+            if (char === '{') {
+                braceCount++;
+                foundOpenBrace = true;
+            } else if (char === '}') {
+                braceCount--;
+            }
+        }
+
+        // Check if we've exited the class
+        if (foundOpenBrace && braceCount === 0) {
+            break;
+        }
+
+        // Look for constructor parameters with public/private/readonly
+        if (line.includes('constructor')) {
+            inConstructor = true;
+        }
+
+        if (inConstructor) {
+            // Match constructor parameter properties
+            const paramMatch = line.match(
+                /(?:public|private|protected|readonly)\s+(\w+)\s*(?::\s*(\w+(?:<[^>]+>)?))?\s*(?:=\s*([^,)]+))?/g
+            );
+
+            if (paramMatch) {
+                for (const param of paramMatch) {
+                    const parts = param.match(
+                        /(?:public|private|protected|readonly)\s+(\w+)\s*(?::\s*(\w+(?:<[^>]+>)?))?\s*(?:=\s*(.+))?/
+                    );
+                    if (parts) {
+                        properties.push({
+                            name: parts[1],
+                            type: parts[2] || 'any',
+                            defaultValue: parts[3]?.trim(),
+                        });
+                    }
+                }
+            }
+
+            // Check if constructor ends
+            if (line.includes(')') && braceCount <= 2) {
+                inConstructor = false;
+            }
+        }
+
+        // Look for class property declarations
+        const propMatch = line.match(/^\s*(\w+)\s*:\s*(\w+(?:<[^>]+>)?)\s*(?:=\s*(.+))?;/);
+        if (propMatch && !inConstructor) {
+            properties.push({
+                name: propMatch[1],
+                type: propMatch[2],
+                defaultValue: propMatch[3]?.trim(),
+            });
+        }
+    }
+
+    return properties;
+}
+
+/**
+ * Scans the workspace for ECS systems
+ */
+export async function scanForSystems(): Promise<SystemInfo[]> {
+    const systems: SystemInfo[] = [];
+
+    try {
+        const files = await vscode.workspace.findFiles('**/*.{ts,js}', '**/node_modules/**');
+
+        for (const file of files) {
+            try {
+                const document = await vscode.workspace.openTextDocument(file);
+                const text = document.getText();
+                const lines = text.split('\n');
+
+                // Find createSystem calls
+                for (let i = 0; i < lines.length; i++) {
+                    const line = lines[i];
+
+                    if (line.includes('.createSystem')) {
+                        const systemInfo = parseSystemDefinition(lines, i, file.fsPath);
+                        if (systemInfo) {
+                            systems.push(systemInfo);
+                        }
+                    }
+                }
+            } catch {
+                // Skip files that can't be read
+            }
+        }
+    } catch {
+        // Return empty if workspace scan fails
+    }
+
+    return systems;
+}
+
+/**
+ * Parses a system definition from lines
+ */
+function parseSystemDefinition(
+    lines: string[],
+    startLine: number,
+    filePath: string
+): SystemInfo | null {
+    // Gather lines until we have the full createSystem call
+    let fullText = '';
+    let parenCount = 0;
+    let started = false;
+
+    for (let i = startLine; i < lines.length && i < startLine + 30; i++) {
+        fullText += lines[i] + '\n';
+
+        for (const char of lines[i]) {
+            if (char === '(') {
+                parenCount++;
+                started = true;
+            } else if (char === ')') {
+                parenCount--;
+            }
+        }
+
+        // Check if we've completed the call
+        if (started && parenCount === 0) {
+            break;
+        }
+    }
+
+    // Extract system name
+    const nameMatch = fullText.match(/\.createSystem\s*\(\s*['"`](\w+)['"`]/);
+    if (!nameMatch) {
+        return null;
+    }
+
+    const name = nameMatch[1];
+
+    // Extract query components
+    const queryComponents: string[] = [];
+    const allMatch = fullText.match(/all\s*:\s*\[([^\]]*)\]/);
+    if (allMatch) {
+        const components = allMatch[1].match(/\w+/g);
+        if (components) {
+            queryComponents.push(...components);
+        }
+    }
+
+    // Extract priority
+    let priority: number | undefined;
+    const priorityMatch = fullText.match(/priority\s*:\s*(\d+)/);
+    if (priorityMatch) {
+        priority = parseInt(priorityMatch[1], 10);
+    }
+
+    // Check if fixed update (last boolean parameter)
+    const isFixedUpdate = fullText.includes(', true)') || fullText.includes(',true)');
+
+    // Extract tags
+    const tags: string[] = [];
+    const tagsMatch = fullText.match(/tags\s*:\s*\[([^\]]*)\]/);
+    if (tagsMatch) {
+        const tagStrings = tagsMatch[1].match(/['"`](\w+)['"`]/g);
+        if (tagStrings) {
+            tags.push(...tagStrings.map((t) => t.replace(/['"`]/g, '')));
+        }
+    }
+
+    return {
+        name,
+        filePath,
+        line: startLine + 1,
+        queryComponents,
+        priority,
+        isFixedUpdate,
+        tags,
+    };
+}
+
+/**
+ * Scans the workspace for entity prefabs
+ */
+export async function scanForPrefabs(): Promise<PrefabInfo[]> {
+    const prefabs: PrefabInfo[] = [];
+
+    try {
+        const files = await vscode.workspace.findFiles('**/*.{ts,js}', '**/node_modules/**');
+
+        for (const file of files) {
+            try {
+                const document = await vscode.workspace.openTextDocument(file);
+                const text = document.getText();
+                const lines = text.split('\n');
+
+                // Find registerPrefab calls
+                for (let i = 0; i < lines.length; i++) {
+                    const line = lines[i];
+
+                    if (line.includes('.registerPrefab')) {
+                        const prefabInfo = parsePrefabDefinition(lines, i, file.fsPath);
+                        if (prefabInfo) {
+                            prefabs.push(prefabInfo);
+                        }
+                    }
+
+                    // Also look for EntityPrefab type annotations
+                    if (line.includes(': EntityPrefab')) {
+                        const prefabInfo = parsePrefabObject(lines, i, file.fsPath);
+                        if (prefabInfo) {
+                            prefabs.push(prefabInfo);
+                        }
+                    }
+                }
+            } catch {
+                // Skip files that can't be read
+            }
+        }
+    } catch {
+        // Return empty if workspace scan fails
+    }
+
+    return prefabs;
+}
+
+/**
+ * Parses a prefab definition from registerPrefab call
+ */
+function parsePrefabDefinition(
+    lines: string[],
+    startLine: number,
+    filePath: string
+): PrefabInfo | null {
+    // Gather lines until we have the full registerPrefab call
+    let fullText = '';
+    let parenCount = 0;
+    let started = false;
+
+    for (let i = startLine; i < lines.length && i < startLine + 30; i++) {
+        fullText += lines[i] + '\n';
+
+        for (const char of lines[i]) {
+            if (char === '(') {
+                parenCount++;
+                started = true;
+            } else if (char === ')') {
+                parenCount--;
+            }
+        }
+
+        if (started && parenCount === 0) {
+            break;
+        }
+    }
+
+    // Extract prefab name
+    const nameMatch = fullText.match(/\.registerPrefab\s*\(\s*['"`](\w+)['"`]/);
+    if (!nameMatch) {
+        return null;
+    }
+
+    const name = nameMatch[1];
+
+    // Extract components from the prefab definition
+    const components: string[] = [];
+    const componentsMatch = fullText.match(/components\s*:\s*\[([^\]]*)\]/s);
+    if (componentsMatch) {
+        const typeMatches = componentsMatch[1].match(/type\s*:\s*(\w+)/g);
+        if (typeMatches) {
+            components.push(...typeMatches.map((t) => t.replace(/type\s*:\s*/, '')));
+        }
+    }
+
+    // Extract tags
+    const tags: string[] = [];
+    const tagsMatch = fullText.match(/tags\s*:\s*\[([^\]]*)\]/);
+    if (tagsMatch) {
+        const tagStrings = tagsMatch[1].match(/['"`](\w+)['"`]/g);
+        if (tagStrings) {
+            tags.push(...tagStrings.map((t) => t.replace(/['"`]/g, '')));
+        }
+    }
+
+    return {
+        name,
+        filePath,
+        line: startLine + 1,
+        components,
+        tags,
+    };
+}
+
+/**
+ * Parses a prefab from EntityPrefab type annotation
+ */
+function parsePrefabObject(
+    lines: string[],
+    startLine: number,
+    filePath: string
+): PrefabInfo | null {
+    // Get the variable name
+    const varMatch = lines[startLine].match(/(?:const|let)\s+(\w+)\s*:\s*EntityPrefab/);
+    if (!varMatch) {
+        return null;
+    }
+
+    // Gather lines until we have the full object
+    let fullText = '';
+    let braceCount = 0;
+    let started = false;
+
+    for (let i = startLine; i < lines.length && i < startLine + 30; i++) {
+        fullText += lines[i] + '\n';
+
+        for (const char of lines[i]) {
+            if (char === '{') {
+                braceCount++;
+                started = true;
+            } else if (char === '}') {
+                braceCount--;
+            }
+        }
+
+        if (started && braceCount === 0) {
+            break;
+        }
+    }
+
+    // Extract name from object
+    const nameMatch = fullText.match(/name\s*:\s*['"`](\w+)['"`]/);
+    const name = nameMatch ? nameMatch[1] : varMatch[1];
+
+    // Extract components
+    const components: string[] = [];
+    const componentsMatch = fullText.match(/components\s*:\s*\[([^\]]*)\]/s);
+    if (componentsMatch) {
+        const typeMatches = componentsMatch[1].match(/type\s*:\s*(\w+)/g);
+        if (typeMatches) {
+            components.push(...typeMatches.map((t) => t.replace(/type\s*:\s*/, '')));
+        }
+    }
+
+    // Extract tags
+    const tags: string[] = [];
+    const tagsMatch = fullText.match(/tags\s*:\s*\[([^\]]*)\]/);
+    if (tagsMatch) {
+        const tagStrings = tagsMatch[1].match(/['"`](\w+)['"`]/g);
+        if (tagStrings) {
+            tags.push(...tagStrings.map((t) => t.replace(/['"`]/g, '')));
+        }
+    }
+
+    return {
+        name,
+        filePath,
+        line: startLine + 1,
+        components,
+        tags,
+    };
+}

--- a/packages/vscode-extension/src/views/ComponentsTreeProvider.ts
+++ b/packages/vscode-extension/src/views/ComponentsTreeProvider.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import { type ComponentInfo, scanForComponents } from '../utils/ecsScanner';
+
+export class ComponentsTreeProvider implements vscode.TreeDataProvider<ComponentItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<ComponentItem | undefined | null | void> =
+        new vscode.EventEmitter<ComponentItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<ComponentItem | undefined | null | void> =
+        this._onDidChangeTreeData.event;
+
+    private components: ComponentInfo[] = [];
+
+    constructor() {
+        this.scanWorkspace();
+    }
+
+    refresh(): void {
+        this.scanWorkspace();
+        this._onDidChangeTreeData.fire();
+    }
+
+    private async scanWorkspace(): Promise<void> {
+        this.components = await scanForComponents();
+    }
+
+    getTreeItem(element: ComponentItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: ComponentItem): Promise<ComponentItem[]> {
+        if (element) {
+            // Return component properties
+            return element.componentInfo.properties.map(
+                (prop) =>
+                    new ComponentItem(
+                        `${prop.name}: ${prop.type}`,
+                        vscode.TreeItemCollapsibleState.None,
+                        element.componentInfo,
+                        'property'
+                    )
+            );
+        }
+
+        // Return top-level components
+        if (this.components.length === 0) {
+            await this.scanWorkspace();
+        }
+
+        return this.components.map(
+            (comp) =>
+                new ComponentItem(
+                    comp.name,
+                    comp.properties.length > 0
+                        ? vscode.TreeItemCollapsibleState.Collapsed
+                        : vscode.TreeItemCollapsibleState.None,
+                    comp,
+                    'component'
+                )
+        );
+    }
+}
+
+export class ComponentItem extends vscode.TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly componentInfo: ComponentInfo,
+        public readonly itemType: 'component' | 'property'
+    ) {
+        super(label, collapsibleState);
+
+        if (itemType === 'component') {
+            this.tooltip = `${componentInfo.name}\n${componentInfo.filePath}:${componentInfo.line}`;
+            this.description = componentInfo.filePath.split('/').pop();
+            this.iconPath = new vscode.ThemeIcon('symbol-class');
+            this.contextValue = 'component';
+
+            this.command = {
+                command: 'vscode.open',
+                title: 'Open Component',
+                arguments: [
+                    vscode.Uri.file(componentInfo.filePath),
+                    {
+                        selection: new vscode.Range(
+                            componentInfo.line - 1,
+                            0,
+                            componentInfo.line - 1,
+                            0
+                        ),
+                    },
+                ],
+            };
+        } else {
+            this.iconPath = new vscode.ThemeIcon('symbol-field');
+            this.contextValue = 'property';
+        }
+    }
+}

--- a/packages/vscode-extension/src/views/EntitiesTreeProvider.ts
+++ b/packages/vscode-extension/src/views/EntitiesTreeProvider.ts
@@ -1,0 +1,148 @@
+import * as vscode from 'vscode';
+import { type PrefabInfo, scanForPrefabs } from '../utils/ecsScanner';
+
+export class EntitiesTreeProvider implements vscode.TreeDataProvider<EntityItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<EntityItem | undefined | null | void> =
+        new vscode.EventEmitter<EntityItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<EntityItem | undefined | null | void> =
+        this._onDidChangeTreeData.event;
+
+    private prefabs: PrefabInfo[] = [];
+
+    constructor() {
+        this.scanWorkspace();
+    }
+
+    refresh(): void {
+        this.scanWorkspace();
+        this._onDidChangeTreeData.fire();
+    }
+
+    private async scanWorkspace(): Promise<void> {
+        this.prefabs = await scanForPrefabs();
+    }
+
+    getTreeItem(element: EntityItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: EntityItem): Promise<EntityItem[]> {
+        if (element) {
+            // Return prefab details
+            const items: EntityItem[] = [];
+
+            if (element.prefabInfo.components.length > 0) {
+                for (const comp of element.prefabInfo.components) {
+                    items.push(
+                        new EntityItem(
+                            comp,
+                            vscode.TreeItemCollapsibleState.None,
+                            element.prefabInfo,
+                            'component'
+                        )
+                    );
+                }
+            }
+
+            if (element.prefabInfo.tags.length > 0) {
+                items.push(
+                    new EntityItem(
+                        `Tags: ${element.prefabInfo.tags.join(', ')}`,
+                        vscode.TreeItemCollapsibleState.None,
+                        element.prefabInfo,
+                        'tags'
+                    )
+                );
+            }
+
+            return items;
+        }
+
+        // Return top-level prefabs
+        if (this.prefabs.length === 0) {
+            await this.scanWorkspace();
+        }
+
+        if (this.prefabs.length === 0) {
+            return [
+                new EntityItem(
+                    'No prefabs found',
+                    vscode.TreeItemCollapsibleState.None,
+                    {
+                        name: '',
+                        filePath: '',
+                        line: 0,
+                        components: [],
+                        tags: [],
+                    },
+                    'empty'
+                ),
+            ];
+        }
+
+        return this.prefabs.map(
+            (prefab) =>
+                new EntityItem(
+                    prefab.name,
+                    prefab.components.length > 0 || prefab.tags.length > 0
+                        ? vscode.TreeItemCollapsibleState.Collapsed
+                        : vscode.TreeItemCollapsibleState.None,
+                    prefab,
+                    'prefab'
+                )
+        );
+    }
+}
+
+export class EntityItem extends vscode.TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly prefabInfo: PrefabInfo,
+        public readonly itemType: 'prefab' | 'component' | 'tags' | 'empty'
+    ) {
+        super(label, collapsibleState);
+
+        switch (itemType) {
+            case 'prefab':
+                this.tooltip = `${prefabInfo.name}\n${prefabInfo.filePath}:${prefabInfo.line}`;
+                this.description = `${prefabInfo.components.length} components`;
+                this.iconPath = new vscode.ThemeIcon('package');
+                this.contextValue = 'prefab';
+
+                if (prefabInfo.filePath) {
+                    this.command = {
+                        command: 'vscode.open',
+                        title: 'Open Prefab',
+                        arguments: [
+                            vscode.Uri.file(prefabInfo.filePath),
+                            {
+                                selection: new vscode.Range(
+                                    prefabInfo.line - 1,
+                                    0,
+                                    prefabInfo.line - 1,
+                                    0
+                                ),
+                            },
+                        ],
+                    };
+                }
+                break;
+
+            case 'component':
+                this.iconPath = new vscode.ThemeIcon('symbol-class');
+                this.contextValue = 'prefabComponent';
+                break;
+
+            case 'tags':
+                this.iconPath = new vscode.ThemeIcon('tag');
+                this.contextValue = 'prefabTags';
+                break;
+
+            case 'empty':
+                this.iconPath = new vscode.ThemeIcon('info');
+                this.contextValue = 'empty';
+                break;
+        }
+    }
+}

--- a/packages/vscode-extension/src/views/SystemsTreeProvider.ts
+++ b/packages/vscode-extension/src/views/SystemsTreeProvider.ts
@@ -1,0 +1,120 @@
+import * as vscode from 'vscode';
+import { type SystemInfo, scanForSystems } from '../utils/ecsScanner';
+
+export class SystemsTreeProvider implements vscode.TreeDataProvider<SystemItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<SystemItem | undefined | null | void> =
+        new vscode.EventEmitter<SystemItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<SystemItem | undefined | null | void> =
+        this._onDidChangeTreeData.event;
+
+    private systems: SystemInfo[] = [];
+
+    constructor() {
+        this.scanWorkspace();
+    }
+
+    refresh(): void {
+        this.scanWorkspace();
+        this._onDidChangeTreeData.fire();
+    }
+
+    private async scanWorkspace(): Promise<void> {
+        this.systems = await scanForSystems();
+    }
+
+    getTreeItem(element: SystemItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: SystemItem): Promise<SystemItem[]> {
+        if (element) {
+            // Return system details
+            const items: SystemItem[] = [];
+
+            if (element.systemInfo.queryComponents.length > 0) {
+                items.push(
+                    new SystemItem(
+                        `Query: ${element.systemInfo.queryComponents.join(', ')}`,
+                        vscode.TreeItemCollapsibleState.None,
+                        element.systemInfo,
+                        'query'
+                    )
+                );
+            }
+
+            if (element.systemInfo.priority !== undefined) {
+                items.push(
+                    new SystemItem(
+                        `Priority: ${element.systemInfo.priority}`,
+                        vscode.TreeItemCollapsibleState.None,
+                        element.systemInfo,
+                        'priority'
+                    )
+                );
+            }
+
+            if (element.systemInfo.isFixedUpdate) {
+                items.push(
+                    new SystemItem(
+                        'Type: Fixed Update',
+                        vscode.TreeItemCollapsibleState.None,
+                        element.systemInfo,
+                        'type'
+                    )
+                );
+            }
+
+            return items;
+        }
+
+        // Return top-level systems
+        if (this.systems.length === 0) {
+            await this.scanWorkspace();
+        }
+
+        // Sort by priority (higher first)
+        const sortedSystems = this.systems.toSorted(
+            (a, b) => (b.priority ?? 0) - (a.priority ?? 0)
+        );
+
+        return sortedSystems.map(
+            (sys) =>
+                new SystemItem(sys.name, vscode.TreeItemCollapsibleState.Collapsed, sys, 'system')
+        );
+    }
+}
+
+export class SystemItem extends vscode.TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly systemInfo: SystemInfo,
+        public readonly itemType: 'system' | 'query' | 'priority' | 'type'
+    ) {
+        super(label, collapsibleState);
+
+        if (itemType === 'system') {
+            this.tooltip = `${systemInfo.name}\n${systemInfo.filePath}:${systemInfo.line}`;
+            this.description = systemInfo.isFixedUpdate ? 'fixed' : 'variable';
+            this.iconPath = new vscode.ThemeIcon('symbol-method');
+            this.contextValue = 'system';
+
+            this.command = {
+                command: 'vscode.open',
+                title: 'Open System',
+                arguments: [
+                    vscode.Uri.file(systemInfo.filePath),
+                    {
+                        selection: new vscode.Range(systemInfo.line - 1, 0, systemInfo.line - 1, 0),
+                    },
+                ],
+            };
+        } else if (itemType === 'query') {
+            this.iconPath = new vscode.ThemeIcon('filter');
+        } else if (itemType === 'priority') {
+            this.iconPath = new vscode.ThemeIcon('arrow-up');
+        } else {
+            this.iconPath = new vscode.ThemeIcon('clock');
+        }
+    }
+}

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
Initial implementation of VS Code extension with:
- Code snippets for components, systems, prefabs, queries, and more
- IntelliSense enhancements for component/system/engine methods
- CodeLens showing component usage information
- Hover documentation for ECS patterns and APIs
- Tree view providers for Components, Systems, and Entities
- Commands for creating components, systems, and prefabs
- ECS scanner utility for workspace analysis
- Jest test infrastructure with vscode mocks

Features:
- 30+ TypeScript/JavaScript snippets with orion-* and ecs-* prefixes
- Smart completion for queries, tags, and entity/engine methods
- Activity bar with OrionECS explorer views
- Configurable settings for CodeLens and snippets

Starts #95