### PR TITLE
feat(vscode): Add refactoring support to VSCode extension

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -82,6 +82,22 @@
       {
         "command": "orion-ecs.goToDefinition",
         "title": "Orion: Go to ECS Definition"
+      },
+      {
+        "command": "orion-ecs.renameComponent",
+        "title": "Orion: Rename Component"
+      },
+      {
+        "command": "orion-ecs.previewComponentReferences",
+        "title": "Orion: Preview Component References"
+      },
+      {
+        "command": "orion-ecs.moveComponentToFile",
+        "title": "Orion: Move Component to File"
+      },
+      {
+        "command": "orion-ecs.extractComponent",
+        "title": "Orion: Extract to Component"
       }
     ],
     "viewsContainers": {
@@ -127,9 +143,34 @@
           "command": "orion-ecs.createSystem",
           "group": "orion-ecs@2",
           "when": "editorLangId == typescript || editorLangId == javascript"
+        },
+        {
+          "submenu": "orion-ecs.refactor",
+          "group": "orion-ecs@3",
+          "when": "editorLangId == typescript || editorLangId == javascript"
+        }
+      ],
+      "orion-ecs.refactor": [
+        {
+          "command": "orion-ecs.renameComponent",
+          "group": "refactor@1"
+        },
+        {
+          "command": "orion-ecs.previewComponentReferences",
+          "group": "refactor@2"
+        },
+        {
+          "command": "orion-ecs.moveComponentToFile",
+          "group": "refactor@3"
         }
       ]
     },
+    "submenus": [
+      {
+        "id": "orion-ecs.refactor",
+        "label": "Orion: Refactor"
+      }
+    ],
     "snippets": [
       {
         "language": "typescript",

--- a/packages/vscode-extension/src/__tests__/__mocks__/vscode.ts
+++ b/packages/vscode-extension/src/__tests__/__mocks__/vscode.ts
@@ -7,21 +7,21 @@ export const Uri = {
     parse: (str: string) => ({ toString: () => str }),
 };
 
-export const Range = class {
+export class Range {
     constructor(
         public startLine: number,
         public startChar: number,
         public endLine: number,
         public endChar: number
     ) {}
-};
+}
 
-export const Position = class {
+export class Position {
     constructor(
         public line: number,
         public character: number
     ) {}
-};
+}
 
 export const TreeItemCollapsibleState = {
     None: 0,
@@ -170,6 +170,79 @@ export const languages = {
     registerCodeLensProvider: () => ({ dispose: () => {} }),
     registerCompletionItemProvider: () => ({ dispose: () => {} }),
     registerHoverProvider: () => ({ dispose: () => {} }),
+    registerRenameProvider: () => ({ dispose: () => {} }),
+    registerCodeActionsProvider: () => ({ dispose: () => {} }),
+};
+
+export const WorkspaceEdit = class {
+    private edits: Map<string, { range: Range; newText: string }[]> = new Map();
+
+    replace(uri: { fsPath: string }, range: Range, newText: string) {
+        const key = uri.fsPath;
+        if (!this.edits.has(key)) {
+            this.edits.set(key, []);
+        }
+        const editList = this.edits.get(key);
+        if (editList) {
+            editList.push({ range, newText });
+        }
+    }
+
+    delete(uri: { fsPath: string }, range: Range) {
+        this.replace(uri, range, '');
+    }
+
+    insert(uri: { fsPath: string }, position: Position, text: string) {
+        const range = new Range(
+            position.line,
+            position.character,
+            position.line,
+            position.character
+        );
+        this.replace(uri, range, text);
+    }
+
+    createFile(
+        _uri: { fsPath: string },
+        _options?: { overwrite?: boolean; ignoreIfExists?: boolean }
+    ) {
+        // Mock implementation
+    }
+
+    getEdits() {
+        return this.edits;
+    }
+};
+
+export const CodeAction = class {
+    title: string;
+    kind?: { value: string };
+    command?: unknown;
+
+    constructor(title: string, kind?: { value: string }) {
+        this.title = title;
+        this.kind = kind;
+    }
+};
+
+export const CodeActionKind = {
+    RefactorExtract: { value: 'refactor.extract' },
+    QuickFix: { value: 'quickfix' },
+    Refactor: { value: 'refactor' },
+};
+
+export const ProgressLocation = {
+    Notification: 15,
+    SourceControl: 1,
+    Window: 10,
+};
+
+export const CancellationTokenSource = class {
+    token = { isCancellationRequested: false };
+    cancel() {
+        this.token.isCancellationRequested = true;
+    }
+    dispose() {}
 };
 
 export const commands = {
@@ -195,6 +268,11 @@ export default {
     MarkdownString,
     CodeLens,
     SnippetString,
+    WorkspaceEdit,
+    CodeAction,
+    CodeActionKind,
+    ProgressLocation,
+    CancellationTokenSource,
     window,
     workspace,
     languages,

--- a/packages/vscode-extension/src/__tests__/refactoring.test.ts
+++ b/packages/vscode-extension/src/__tests__/refactoring.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for refactoring utilities and providers
+ */
+
+import { generateExtractedComponent } from '../providers/ExtractComponentCodeActionProvider';
+import {
+    type ComponentReference,
+    ComponentReferenceType,
+    findReferencesInDocument,
+    isLikelyComponentClass,
+    isValidComponentName,
+    summarizeReferences,
+} from '../utils/refactoringUtils';
+
+// Type for mock document that matches what findReferencesInDocument expects
+interface MockDocument {
+    getText: () => string;
+    lineAt: (line: number) => { text: string };
+    uri: { fsPath: string; toString: () => string };
+}
+
+// Mock document helper
+function createMockDocument(content: string): MockDocument {
+    const lines = content.split('\n');
+    return {
+        getText: () => content,
+        lineAt: (line: number) => ({ text: lines[line] }),
+        uri: { fsPath: '/test/file.ts', toString: () => '/test/file.ts' },
+    };
+}
+
+describe('Refactoring Utilities', () => {
+    describe('isValidComponentName', () => {
+        it('should accept valid component names', () => {
+            expect(isValidComponentName('Position')).toBe(true);
+            expect(isValidComponentName('Velocity')).toBe(true);
+            expect(isValidComponentName('Transform2D')).toBe(true);
+            expect(isValidComponentName('PlayerHealth')).toBe(true);
+        });
+
+        it('should reject invalid component names', () => {
+            expect(isValidComponentName('position')).toBe(false);
+            expect(isValidComponentName('123Position')).toBe(false);
+            expect(isValidComponentName('Player_Health')).toBe(false);
+            expect(isValidComponentName('')).toBe(false);
+            expect(isValidComponentName('Position-Value')).toBe(false);
+        });
+    });
+
+    describe('isLikelyComponentClass', () => {
+        it('should identify component class names', () => {
+            expect(isLikelyComponentClass('Position')).toBe(true);
+            expect(isLikelyComponentClass('Velocity')).toBe(true);
+            expect(isLikelyComponentClass('Health')).toBe(true);
+            expect(isLikelyComponentClass('Transform')).toBe(true);
+            expect(isLikelyComponentClass('RigidBody')).toBe(true);
+        });
+
+        it('should reject non-component patterns', () => {
+            expect(isLikelyComponentClass('MovementSystem')).toBe(false);
+            expect(isLikelyComponentClass('EntityManager')).toBe(false);
+            expect(isLikelyComponentClass('GameService')).toBe(false);
+            expect(isLikelyComponentClass('PhysicsController')).toBe(false);
+            expect(isLikelyComponentClass('ComponentProvider')).toBe(false);
+            expect(isLikelyComponentClass('EntityFactory')).toBe(false);
+            expect(isLikelyComponentClass('EngineBuilder')).toBe(false);
+            expect(isLikelyComponentClass('InputHandler')).toBe(false);
+            expect(isLikelyComponentClass('PhysicsPlugin')).toBe(false);
+            expect(isLikelyComponentClass('SpatialQuery')).toBe(false);
+        });
+    });
+
+    describe('findReferencesInDocument', () => {
+        it('should find class definition references', () => {
+            const doc = createMockDocument(`
+export class Position {
+  constructor(public x = 0, public y = 0) {}
+}
+`);
+            const refs = findReferencesInDocument(
+                doc as unknown as Parameters<typeof findReferencesInDocument>[0],
+                'Position'
+            );
+            const classDef = refs.find((r) => r.type === ComponentReferenceType.ClassDefinition);
+            expect(classDef).toBeDefined();
+        });
+
+        it('should find import references', () => {
+            const doc = createMockDocument(`
+import { Position, Velocity } from './components';
+`);
+            const refs = findReferencesInDocument(
+                doc as unknown as Parameters<typeof findReferencesInDocument>[0],
+                'Position'
+            );
+            const importRef = refs.find((r) => r.type === ComponentReferenceType.Import);
+            expect(importRef).toBeDefined();
+        });
+
+        it('should find system query references', () => {
+            const doc = createMockDocument(`
+engine.createSystem('Movement', {
+  all: [Position, Velocity],
+  none: [Frozen]
+}, {
+  act: (entity, pos, vel) => {}
+});
+`);
+            const refs = findReferencesInDocument(
+                doc as unknown as Parameters<typeof findReferencesInDocument>[0],
+                'Position'
+            );
+            const queryRef = refs.find((r) => r.type === ComponentReferenceType.SystemQueryAll);
+            expect(queryRef).toBeDefined();
+        });
+
+        it('should find entity method references', () => {
+            const doc = createMockDocument(`
+entity.addComponent(Position, 100, 200);
+const pos = entity.getComponent(Position);
+if (entity.hasComponent(Position)) {}
+entity.removeComponent(Position);
+`);
+            const refs = findReferencesInDocument(
+                doc as unknown as Parameters<typeof findReferencesInDocument>[0],
+                'Position'
+            );
+            expect(refs.length).toBeGreaterThanOrEqual(4);
+        });
+
+        it('should find singleton references', () => {
+            const doc = createMockDocument(`
+engine.setSingleton(GameTime, 0, 0);
+const time = engine.getSingleton(GameTime);
+`);
+            const refs = findReferencesInDocument(
+                doc as unknown as Parameters<typeof findReferencesInDocument>[0],
+                'GameTime'
+            );
+            const setRef = refs.find((r) => r.type === ComponentReferenceType.SingletonSet);
+            const getRef = refs.find((r) => r.type === ComponentReferenceType.SingletonGet);
+            expect(setRef).toBeDefined();
+            expect(getRef).toBeDefined();
+        });
+
+        it('should find prefab references', () => {
+            const doc = createMockDocument(`
+const playerPrefab = {
+  components: [
+    { type: Position, args: [0, 0] },
+    { type: Health, args: [100] }
+  ]
+};
+`);
+            const refs = findReferencesInDocument(
+                doc as unknown as Parameters<typeof findReferencesInDocument>[0],
+                'Position'
+            );
+            const prefabRef = refs.find((r) => r.type === ComponentReferenceType.PrefabDefinition);
+            expect(prefabRef).toBeDefined();
+        });
+    });
+
+    describe('summarizeReferences', () => {
+        it('should summarize reference counts correctly', () => {
+            const mockUri = { fsPath: '/test.ts', toString: () => '/test.ts' };
+            const mockRange = { start: { line: 0 }, end: { line: 0 } };
+
+            const refs = [
+                {
+                    type: ComponentReferenceType.ClassDefinition,
+                    uri: mockUri,
+                    range: mockRange,
+                    componentName: 'Position',
+                    lineText: '',
+                },
+                {
+                    type: ComponentReferenceType.Import,
+                    uri: mockUri,
+                    range: mockRange,
+                    componentName: 'Position',
+                    lineText: '',
+                },
+                {
+                    type: ComponentReferenceType.Import,
+                    uri: mockUri,
+                    range: mockRange,
+                    componentName: 'Position',
+                    lineText: '',
+                },
+                {
+                    type: ComponentReferenceType.EntityAddComponent,
+                    uri: mockUri,
+                    range: mockRange,
+                    componentName: 'Position',
+                    lineText: '',
+                },
+                {
+                    type: ComponentReferenceType.SystemQueryAll,
+                    uri: mockUri,
+                    range: mockRange,
+                    componentName: 'Position',
+                    lineText: '',
+                },
+            ];
+
+            const summary = summarizeReferences(refs as ComponentReference[]);
+
+            expect(summary).toContain('1 definition');
+            expect(summary).toContain('2 import');
+            expect(summary).toContain('1 entity method');
+            expect(summary).toContain('1 system query');
+        });
+    });
+});
+
+describe('Extract Component', () => {
+    describe('generateExtractedComponent', () => {
+        it('should generate empty component class', () => {
+            const result = generateExtractedComponent('Empty', []);
+            expect(result).toContain('export class Empty');
+            expect(result).toContain('constructor()');
+        });
+
+        it('should generate component with public properties', () => {
+            const result = generateExtractedComponent('Position', [
+                { name: 'x', type: 'number', defaultValue: '0', modifier: 'public' },
+                { name: 'y', type: 'number', defaultValue: '0', modifier: 'public' },
+            ]);
+
+            expect(result).toContain('export class Position');
+            expect(result).toContain('public x: number = 0');
+            expect(result).toContain('public y: number = 0');
+        });
+
+        it('should handle properties without default values', () => {
+            const result = generateExtractedComponent('Health', [
+                { name: 'current', type: 'number' },
+                { name: 'max', type: 'number' },
+            ]);
+
+            expect(result).toContain('public current: number');
+            expect(result).toContain('public max: number');
+            expect(result).not.toContain('=');
+        });
+
+        it('should handle mixed modifiers', () => {
+            const result = generateExtractedComponent('Config', [
+                { name: 'name', type: 'string', modifier: 'public' },
+                { name: 'id', type: 'number', modifier: 'readonly' },
+            ]);
+
+            expect(result).toContain('public name: string');
+            expect(result).toContain('readonly id: number');
+        });
+
+        it('should default modifier to public', () => {
+            const result = generateExtractedComponent('Simple', [
+                { name: 'value', type: 'number' },
+            ]);
+
+            expect(result).toContain('public value: number');
+        });
+    });
+});
+
+describe('Component Rename Patterns', () => {
+    describe('Reference Detection Patterns', () => {
+        it('should match class definition patterns', () => {
+            const patterns = [
+                'class Position {',
+                'export class Position {',
+                'export class Position extends Base {',
+            ];
+
+            for (const pattern of patterns) {
+                const match = pattern.match(/^(?:export\s+)?class\s+Position\b/);
+                expect(match).not.toBeNull();
+            }
+        });
+
+        it('should match entity method patterns', () => {
+            const patterns = [
+                'entity.addComponent(Position, 0, 0)',
+                'entity.getComponent(Position)',
+                'entity.hasComponent(Position)',
+                'entity.removeComponent(Position)',
+            ];
+
+            for (const pattern of patterns) {
+                const match = pattern.match(/\.(add|get|has|remove)Component\s*\(\s*Position/);
+                expect(match).not.toBeNull();
+            }
+        });
+
+        it('should match system query patterns', () => {
+            const pattern = `{
+        all: [Position, Velocity],
+        any: [Flying, Swimming],
+        none: [Frozen]
+      }`;
+
+            const allMatch = pattern.match(/all\s*:\s*\[[^\]]*Position[^\]]*\]/);
+            expect(allMatch).not.toBeNull();
+        });
+
+        it('should match import patterns', () => {
+            const patterns = [
+                "import { Position } from './components';",
+                "import { Position, Velocity } from './components';",
+                "import Position from './Position';",
+            ];
+
+            for (const pattern of patterns) {
+                const match = pattern.match(/import.*Position/);
+                expect(match).not.toBeNull();
+            }
+        });
+
+        it('should match singleton patterns', () => {
+            const patterns = [
+                'engine.setSingleton(Position, 0, 0)',
+                'engine.getSingleton(Position)',
+                'engine.hasSingleton(Position)',
+            ];
+
+            for (const pattern of patterns) {
+                const match = pattern.match(/\.(set|get|has)Singleton\s*\(\s*Position/);
+                expect(match).not.toBeNull();
+            }
+        });
+
+        it('should match prefab type patterns', () => {
+            const pattern = '{ type: Position, args: [0, 0] }';
+            const match = pattern.match(/type\s*:\s*Position/);
+            expect(match).not.toBeNull();
+        });
+    });
+
+    describe('Word Boundary Detection', () => {
+        it('should not match partial names', () => {
+            const text = 'PositionComponent PositionalData MyPosition';
+            const pattern = /\bPosition\b/g;
+            const matches = text.match(pattern);
+
+            // Should not match PositionComponent or PositionalData or MyPosition
+            expect(matches).toBeNull();
+        });
+
+        it('should match exact names', () => {
+            const text = 'Position, Velocity, Position';
+            const pattern = /\bPosition\b/g;
+            const matches = text.match(pattern);
+
+            expect(matches).toHaveLength(2);
+        });
+    });
+});

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,10 +1,15 @@
 import * as vscode from 'vscode';
 import { registerCommands } from './commands';
 import { ComponentCodeLensProvider } from './providers/ComponentCodeLensProvider';
+import { ComponentRenameProvider } from './providers/ComponentRenameProvider';
 import { ECSCompletionProvider } from './providers/ECSCompletionProvider';
 import { ECSDefinitionProvider } from './providers/ECSDefinitionProvider';
 import { ECSHoverProvider } from './providers/ECSHoverProvider';
 import { ECSReferenceProvider } from './providers/ECSReferenceProvider';
+import {
+    ExtractComponentCodeActionProvider,
+    registerExtractComponentCommand,
+} from './providers/ExtractComponentCodeActionProvider';
 import { ComponentsTreeProvider } from './views/ComponentsTreeProvider';
 import { EntitiesTreeProvider } from './views/EntitiesTreeProvider';
 import { SystemsTreeProvider } from './views/SystemsTreeProvider';
@@ -88,6 +93,36 @@ export function activate(context: vscode.ExtensionContext) {
             referenceProvider
         )
     );
+
+    // Register rename provider for component refactoring
+    const renameProvider = new ComponentRenameProvider();
+    context.subscriptions.push(
+        vscode.languages.registerRenameProvider(
+            [
+                { language: 'typescript', scheme: 'file' },
+                { language: 'javascript', scheme: 'file' },
+            ],
+            renameProvider
+        )
+    );
+
+    // Register code action provider for extract component refactoring
+    const extractProvider = new ExtractComponentCodeActionProvider();
+    context.subscriptions.push(
+        vscode.languages.registerCodeActionsProvider(
+            [
+                { language: 'typescript', scheme: 'file' },
+                { language: 'javascript', scheme: 'file' },
+            ],
+            extractProvider,
+            {
+                providedCodeActionKinds: ExtractComponentCodeActionProvider.providedCodeActionKinds,
+            }
+        )
+    );
+
+    // Register extract component command
+    registerExtractComponentCommand(context, outputChannel);
 
     // Register commands
     registerCommands(context, {

--- a/packages/vscode-extension/src/providers/ComponentRenameProvider.ts
+++ b/packages/vscode-extension/src/providers/ComponentRenameProvider.ts
@@ -1,0 +1,327 @@
+import * as vscode from 'vscode';
+
+/**
+ * Provides rename functionality for ECS component classes.
+ * Handles renaming component class definitions and updating all references
+ * across the workspace, including:
+ * - Class definition and imports
+ * - Entity method calls (addComponent, getComponent, hasComponent, removeComponent)
+ * - System query definitions (all, any, none arrays)
+ * - Prefab definitions
+ * - Type annotations
+ */
+export class ComponentRenameProvider implements vscode.RenameProvider {
+    /**
+     * Prepares the rename operation by validating the symbol can be renamed
+     */
+    async prepareRename(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.Range | { range: vscode.Range; placeholder: string } | undefined> {
+        const wordRange = document.getWordRangeAtPosition(position);
+        if (!wordRange) {
+            return undefined;
+        }
+
+        const word = document.getText(wordRange);
+        const line = document.lineAt(position).text;
+
+        // Check if this is a component class definition
+        if (this.isComponentClassDefinition(line, word)) {
+            return { range: wordRange, placeholder: word };
+        }
+
+        // Check if this is a component reference in an ECS context
+        if (this.isComponentReference(line, word)) {
+            return { range: wordRange, placeholder: word };
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Provides the actual rename edits across the workspace
+     */
+    async provideRenameEdits(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        newName: string,
+        token: vscode.CancellationToken
+    ): Promise<vscode.WorkspaceEdit | undefined> {
+        const wordRange = document.getWordRangeAtPosition(position);
+        if (!wordRange) {
+            return undefined;
+        }
+
+        const oldName = document.getText(wordRange);
+
+        // Validate new name
+        if (!this.isValidComponentName(newName)) {
+            vscode.window.showErrorMessage(
+                'Component names must start with an uppercase letter and contain only alphanumeric characters.'
+            );
+            return undefined;
+        }
+
+        const workspaceEdit = new vscode.WorkspaceEdit();
+
+        // Find all TypeScript/JavaScript files in the workspace
+        const files = await vscode.workspace.findFiles(
+            '**/*.{ts,tsx,js,jsx}',
+            '**/node_modules/**'
+        );
+
+        for (const file of files) {
+            if (token.isCancellationRequested) {
+                return undefined;
+            }
+
+            try {
+                const doc = await vscode.workspace.openTextDocument(file);
+                const edits = this.findComponentReferences(doc, oldName, newName);
+
+                for (const edit of edits) {
+                    workspaceEdit.replace(file, edit.range, edit.newText);
+                }
+            } catch {
+                // Skip files that can't be opened
+            }
+        }
+
+        return workspaceEdit;
+    }
+
+    /**
+     * Finds all references to a component in a document
+     */
+    private findComponentReferences(
+        document: vscode.TextDocument,
+        oldName: string,
+        newName: string
+    ): { range: vscode.Range; newText: string }[] {
+        const edits: { range: vscode.Range; newText: string }[] = [];
+        const text = document.getText();
+        const lines = text.split('\n');
+
+        for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+            const line = lines[lineIndex];
+
+            // Find all occurrences of the component name in this line
+            const lineEdits = this.findLineReferences(line, lineIndex, oldName, newName);
+            edits.push(...lineEdits);
+        }
+
+        return edits;
+    }
+
+    /**
+     * Finds component references in a single line
+     */
+    private findLineReferences(
+        line: string,
+        lineIndex: number,
+        oldName: string,
+        newName: string
+    ): { range: vscode.Range; newText: string }[] {
+        const edits: { range: vscode.Range; newText: string }[] = [];
+
+        // Create pattern to match whole word only
+        const pattern = new RegExp(`\\b${this.escapeRegex(oldName)}\\b`, 'g');
+        let match: RegExpExecArray | null;
+
+        while ((match = pattern.exec(line)) !== null) {
+            const startPos = match.index;
+            const context = this.getContext(line, startPos);
+
+            // Only rename if it's in a valid ECS context
+            if (this.isValidContext(context, line, oldName)) {
+                edits.push({
+                    range: new vscode.Range(
+                        lineIndex,
+                        startPos,
+                        lineIndex,
+                        startPos + oldName.length
+                    ),
+                    newText: newName,
+                });
+            }
+        }
+
+        return edits;
+    }
+
+    /**
+     * Gets the context around a position in the line
+     */
+    private getContext(line: string, position: number): string {
+        // Get up to 50 characters before the position
+        const start = Math.max(0, position - 50);
+        return line.substring(start, position);
+    }
+
+    /**
+     * Checks if the context is valid for component renaming
+     */
+    private isValidContext(context: string, line: string, componentName: string): boolean {
+        // Check for class definition
+        if (line.match(new RegExp(`class\\s+${this.escapeRegex(componentName)}\\b`))) {
+            return true;
+        }
+
+        // Check for import statement
+        if (line.includes('import') && line.includes(componentName)) {
+            return true;
+        }
+
+        // Check for entity method calls
+        const entityMethods = [
+            'addComponent',
+            'getComponent',
+            'hasComponent',
+            'removeComponent',
+            'has',
+            'get',
+            'add',
+        ];
+        for (const method of entityMethods) {
+            if (context.includes(`.${method}(`) || context.includes(`.${method}<`)) {
+                return true;
+            }
+        }
+
+        // Check for query definitions (all, any, none arrays)
+        if (/(?:all|any|none)\s*:\s*\[/.test(context) || /\[\s*$/.test(context)) {
+            // Check if we're inside a query array
+            const beforeContext = line.substring(0, line.indexOf(componentName));
+            if (/(?:all|any|none)\s*:\s*\[[^\]]*$/.test(beforeContext)) {
+                return true;
+            }
+        }
+
+        // Check for prefab component definitions
+        if (/type\s*:\s*$/.test(context)) {
+            return true;
+        }
+
+        // Check for type annotations
+        if (context.includes(':') && !context.includes('=')) {
+            return true;
+        }
+
+        // Check for generic type parameters
+        if (/<\s*$/.test(context) || /<[^>]*,\s*$/.test(context)) {
+            return true;
+        }
+
+        // Check for createSystem query
+        if (line.includes('createSystem') && line.includes(componentName)) {
+            return true;
+        }
+
+        // Check for singleton methods
+        if (
+            context.includes('.setSingleton(') ||
+            context.includes('.getSingleton(') ||
+            context.includes('.hasSingleton(')
+        ) {
+            return true;
+        }
+
+        // Check for export statements
+        if (line.match(/export\s*{[^}]*/) && line.includes(componentName)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the line contains a component class definition
+     */
+    private isComponentClassDefinition(line: string, word: string): boolean {
+        const classMatch = line.match(/^(?:export\s+)?class\s+(\w+)/);
+        if (classMatch && classMatch[1] === word) {
+            return this.isLikelyComponentClass(word);
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the word is a component reference in an ECS context
+     */
+    private isComponentReference(line: string, word: string): boolean {
+        // Must start with uppercase (component naming convention)
+        if (!/^[A-Z]/.test(word)) {
+            return false;
+        }
+
+        // Check for entity method calls
+        if (/\.(add|get|has|remove)Component\s*[(<]/.test(line)) {
+            return true;
+        }
+
+        // Check for query definitions
+        if (/(?:all|any|none)\s*:\s*\[/.test(line)) {
+            return true;
+        }
+
+        // Check for prefab type definitions
+        if (/type\s*:\s*\w+/.test(line)) {
+            return true;
+        }
+
+        // Check for imports
+        if (/import\s*{[^}]*}\s*from/.test(line)) {
+            return true;
+        }
+
+        // Check for singleton methods
+        if (/\.(set|get|has)Singleton\s*[(<]/.test(line)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the class name is likely a component (not a system, manager, etc.)
+     */
+    private isLikelyComponentClass(className: string): boolean {
+        const nonComponentPatterns = [
+            /System$/,
+            /Manager$/,
+            /Service$/,
+            /Controller$/,
+            /Provider$/,
+            /Factory$/,
+            /Builder$/,
+            /Handler$/,
+            /Plugin$/,
+            /Engine$/,
+            /Query$/,
+        ];
+
+        for (const pattern of nonComponentPatterns) {
+            if (pattern.test(className)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates that the new name is a valid component name
+     */
+    private isValidComponentName(name: string): boolean {
+        return /^[A-Z][a-zA-Z0-9]*$/.test(name);
+    }
+
+    /**
+     * Escapes special regex characters
+     */
+    private escapeRegex(str: string): string {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+}

--- a/packages/vscode-extension/src/providers/ExtractComponentCodeActionProvider.ts
+++ b/packages/vscode-extension/src/providers/ExtractComponentCodeActionProvider.ts
@@ -1,0 +1,338 @@
+import * as vscode from 'vscode';
+
+/**
+ * Provides code actions for extracting properties from a component into a new component.
+ * Features:
+ * - Extract selected properties to a new component class
+ * - Auto-generate component class boilerplate
+ * - Update entity creation and system logic
+ */
+export class ExtractComponentCodeActionProvider implements vscode.CodeActionProvider {
+    public static readonly providedCodeActionKinds = [vscode.CodeActionKind.RefactorExtract];
+
+    provideCodeActions(
+        document: vscode.TextDocument,
+        range: vscode.Range,
+        _context: vscode.CodeActionContext,
+        _token: vscode.CancellationToken
+    ): vscode.CodeAction[] | undefined {
+        // Only provide actions if there's a selection
+        if (range.isEmpty) {
+            return undefined;
+        }
+
+        const selectedText = document.getText(range);
+        const componentInfo = this.getContainingComponent(document, range);
+
+        if (!componentInfo) {
+            return undefined;
+        }
+
+        // Check if the selection contains extractable properties
+        const properties = this.parseSelectedProperties(selectedText);
+        if (properties.length === 0) {
+            return undefined;
+        }
+
+        const actions: vscode.CodeAction[] = [];
+
+        // Create the extract component action
+        const extractAction = new vscode.CodeAction(
+            `Extract ${properties.length} propert${properties.length === 1 ? 'y' : 'ies'} to new component`,
+            vscode.CodeActionKind.RefactorExtract
+        );
+
+        extractAction.command = {
+            title: 'Extract Component',
+            command: 'orion-ecs.extractComponent',
+            arguments: [document.uri, range, componentInfo.name, componentInfo.range, properties],
+        };
+
+        actions.push(extractAction);
+
+        return actions;
+    }
+
+    /**
+     * Gets information about the component class containing the selection
+     */
+    private getContainingComponent(
+        document: vscode.TextDocument,
+        range: vscode.Range
+    ): { name: string; range: vscode.Range } | undefined {
+        const text = document.getText();
+        const lines = text.split('\n');
+
+        // Search backwards from the selection to find the class definition
+        for (let i = range.start.line; i >= 0; i--) {
+            const line = lines[i];
+            const classMatch = line.match(/^(?:export\s+)?class\s+(\w+)/);
+
+            if (classMatch) {
+                const className = classMatch[1];
+
+                // Verify it's likely a component
+                if (this.isLikelyComponent(className)) {
+                    // Find the end of the class
+                    const classEnd = this.findClassEnd(lines, i);
+                    return {
+                        name: className,
+                        range: new vscode.Range(i, 0, classEnd, lines[classEnd].length),
+                    };
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Finds the end line of a class definition
+     */
+    private findClassEnd(lines: string[], startLine: number): number {
+        let braceCount = 0;
+        let foundOpenBrace = false;
+
+        for (let i = startLine; i < lines.length; i++) {
+            for (const char of lines[i]) {
+                if (char === '{') {
+                    braceCount++;
+                    foundOpenBrace = true;
+                } else if (char === '}') {
+                    braceCount--;
+                }
+            }
+
+            if (foundOpenBrace && braceCount === 0) {
+                return i;
+            }
+        }
+
+        return lines.length - 1;
+    }
+
+    /**
+     * Parses selected text to extract property definitions
+     */
+    private parseSelectedProperties(
+        text: string
+    ): { name: string; type: string; defaultValue?: string; modifier?: string }[] {
+        const properties: {
+            name: string;
+            type: string;
+            defaultValue?: string;
+            modifier?: string;
+        }[] = [];
+        const lines = text.split('\n');
+
+        for (const line of lines) {
+            // Match constructor parameter properties
+            const paramMatch = line.match(
+                /(public|private|protected|readonly)\s+(\w+)\s*(?::\s*([^=,)]+))?\s*(?:=\s*([^,)]+))?/
+            );
+
+            if (paramMatch) {
+                properties.push({
+                    modifier: paramMatch[1],
+                    name: paramMatch[2],
+                    type: paramMatch[3]?.trim() || 'any',
+                    defaultValue: paramMatch[4]?.trim(),
+                });
+                continue;
+            }
+
+            // Match class property declarations
+            const propMatch = line.match(/^\s*(\w+)\s*(?::\s*([^=;]+))?\s*(?:=\s*([^;]+))?;/);
+
+            if (propMatch && !line.includes('constructor')) {
+                properties.push({
+                    name: propMatch[1],
+                    type: propMatch[2]?.trim() || 'any',
+                    defaultValue: propMatch[3]?.trim(),
+                });
+            }
+        }
+
+        return properties;
+    }
+
+    /**
+     * Determines if a class name is likely a component
+     */
+    private isLikelyComponent(className: string): boolean {
+        const nonComponentPatterns = [
+            /System$/,
+            /Manager$/,
+            /Service$/,
+            /Controller$/,
+            /Provider$/,
+            /Factory$/,
+            /Builder$/,
+            /Handler$/,
+            /Plugin$/,
+            /Engine$/,
+            /Query$/,
+        ];
+
+        for (const pattern of nonComponentPatterns) {
+            if (pattern.test(className)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+/**
+ * Generates a new component class from extracted properties
+ */
+export function generateExtractedComponent(
+    name: string,
+    properties: { name: string; type: string; defaultValue?: string; modifier?: string }[]
+): string {
+    if (properties.length === 0) {
+        return `export class ${name} {
+  constructor() {}
+}`;
+    }
+
+    const constructorParams = properties
+        .map((p) => {
+            const modifier = p.modifier || 'public';
+            const type = p.type !== 'any' ? `: ${p.type}` : '';
+            const defaultVal = p.defaultValue ? ` = ${p.defaultValue}` : '';
+            return `    ${modifier} ${p.name}${type}${defaultVal}`;
+        })
+        .join(',\n');
+
+    return `export class ${name} {
+  constructor(
+${constructorParams}
+  ) {}
+}`;
+}
+
+/**
+ * Registers the extract component command
+ */
+export function registerExtractComponentCommand(
+    context: vscode.ExtensionContext,
+    outputChannel: vscode.OutputChannel
+): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'orion-ecs.extractComponent',
+            async (
+                documentUri: vscode.Uri,
+                selectionRange: vscode.Range,
+                sourceComponentName: string,
+                sourceComponentRange: vscode.Range,
+                properties: {
+                    name: string;
+                    type: string;
+                    defaultValue?: string;
+                    modifier?: string;
+                }[]
+            ) => {
+                // Prompt for new component name
+                const newName = await vscode.window.showInputBox({
+                    prompt: 'Enter name for the new component',
+                    placeHolder: 'NewComponent',
+                    validateInput: (value) => {
+                        if (!value) {
+                            return 'Component name is required';
+                        }
+                        if (!/^[A-Z][a-zA-Z0-9]*$/.test(value)) {
+                            return 'Component name must start with uppercase letter';
+                        }
+                        return null;
+                    },
+                });
+
+                if (!newName) {
+                    return;
+                }
+
+                // Ask where to place the new component
+                const placement = await vscode.window.showQuickPick(
+                    [
+                        { label: 'Same file', description: 'Add above the current component' },
+                        { label: 'New file', description: 'Create a new file for the component' },
+                    ],
+                    { placeHolder: 'Where should the new component be created?' }
+                );
+
+                if (!placement) {
+                    return;
+                }
+
+                // Open document to ensure it's accessible for edits
+                await vscode.workspace.openTextDocument(documentUri);
+                const workspaceEdit = new vscode.WorkspaceEdit();
+                const newComponentCode = generateExtractedComponent(newName, properties);
+
+                if (placement.label === 'Same file') {
+                    // Insert new component above the source component
+                    const insertPosition = new vscode.Position(sourceComponentRange.start.line, 0);
+                    workspaceEdit.insert(documentUri, insertPosition, newComponentCode + '\n\n');
+                } else {
+                    // Create a new file
+                    const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri);
+                    if (!workspaceFolder) {
+                        vscode.window.showErrorMessage('Could not determine workspace folder');
+                        return;
+                    }
+
+                    // Determine the directory of the source file
+                    const sourceDir = documentUri.fsPath.substring(
+                        0,
+                        documentUri.fsPath.lastIndexOf('/')
+                    );
+                    const newFilePath = `${sourceDir}/${newName}.ts`;
+                    const newFileUri = vscode.Uri.file(newFilePath);
+
+                    workspaceEdit.createFile(newFileUri, {
+                        overwrite: false,
+                        ignoreIfExists: true,
+                    });
+                    workspaceEdit.insert(newFileUri, new vscode.Position(0, 0), newComponentCode);
+
+                    // Add import to the source file
+                    const importStatement = `import { ${newName} } from './${newName}';\n`;
+                    workspaceEdit.insert(documentUri, new vscode.Position(0, 0), importStatement);
+                }
+
+                // Remove the extracted properties from the source component
+                workspaceEdit.delete(documentUri, selectionRange);
+
+                // Apply the edits
+                const success = await vscode.workspace.applyEdit(workspaceEdit);
+
+                if (success) {
+                    outputChannel.appendLine(
+                        `Extracted ${properties.length} properties from ${sourceComponentName} to ${newName}`
+                    );
+
+                    // Offer to update references
+                    const updateRefs = await vscode.window.showInformationMessage(
+                        `Component "${newName}" created. Would you like to find and update entity references?`,
+                        'Find References',
+                        'Skip'
+                    );
+
+                    if (updateRefs === 'Find References') {
+                        // Search for places where the source component is used
+                        await vscode.commands.executeCommand('workbench.action.findInFiles', {
+                            query: `addComponent\\s*\\(\\s*${sourceComponentName}`,
+                            triggerSearch: true,
+                            isRegex: true,
+                        });
+                    }
+                } else {
+                    vscode.window.showErrorMessage('Failed to extract component');
+                }
+            }
+        )
+    );
+}

--- a/packages/vscode-extension/src/utils/refactoringUtils.ts
+++ b/packages/vscode-extension/src/utils/refactoringUtils.ts
@@ -1,0 +1,388 @@
+import * as vscode from 'vscode';
+
+/**
+ * Reference types for component usage tracking
+ */
+export enum ComponentReferenceType {
+    ClassDefinition = 'class_definition',
+    Import = 'import',
+    EntityAddComponent = 'entity_add_component',
+    EntityGetComponent = 'entity_get_component',
+    EntityHasComponent = 'entity_has_component',
+    EntityRemoveComponent = 'entity_remove_component',
+    SystemQueryAll = 'system_query_all',
+    SystemQueryAny = 'system_query_any',
+    SystemQueryNone = 'system_query_none',
+    PrefabDefinition = 'prefab_definition',
+    SingletonSet = 'singleton_set',
+    SingletonGet = 'singleton_get',
+    TypeAnnotation = 'type_annotation',
+    GenericParameter = 'generic_parameter',
+    Export = 'export',
+}
+
+/**
+ * Represents a reference to a component in the codebase
+ */
+export interface ComponentReference {
+    type: ComponentReferenceType;
+    uri: vscode.Uri;
+    range: vscode.Range;
+    componentName: string;
+    lineText: string;
+}
+
+/**
+ * Finds all references to a component across the workspace
+ */
+export async function findComponentReferences(
+    componentName: string,
+    cancellationToken?: vscode.CancellationToken
+): Promise<ComponentReference[]> {
+    const references: ComponentReference[] = [];
+    const files = await vscode.workspace.findFiles('**/*.{ts,tsx,js,jsx}', '**/node_modules/**');
+
+    for (const file of files) {
+        if (cancellationToken?.isCancellationRequested) {
+            break;
+        }
+
+        try {
+            const document = await vscode.workspace.openTextDocument(file);
+            const fileRefs = findReferencesInDocument(document, componentName);
+            references.push(...fileRefs);
+        } catch {
+            // Skip files that can't be opened
+        }
+    }
+
+    return references;
+}
+
+/**
+ * Finds all references to a component in a single document
+ */
+export function findReferencesInDocument(
+    document: vscode.TextDocument,
+    componentName: string
+): ComponentReference[] {
+    const references: ComponentReference[] = [];
+    const text = document.getText();
+    const lines = text.split('\n');
+
+    const escapedName = escapeRegex(componentName);
+    const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
+
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        const line = lines[lineIndex];
+        let match: RegExpExecArray | null;
+
+        pattern.lastIndex = 0; // Reset regex state
+        while ((match = pattern.exec(line)) !== null) {
+            const refType = classifyReference(line, match.index, componentName);
+
+            if (refType) {
+                references.push({
+                    type: refType,
+                    uri: document.uri,
+                    range: new vscode.Range(
+                        lineIndex,
+                        match.index,
+                        lineIndex,
+                        match.index + componentName.length
+                    ),
+                    componentName,
+                    lineText: line,
+                });
+            }
+        }
+    }
+
+    return references;
+}
+
+/**
+ * Classifies the type of component reference based on context
+ */
+function classifyReference(
+    line: string,
+    position: number,
+    componentName: string
+): ComponentReferenceType | null {
+    const beforeText = line.substring(0, position);
+    const afterText = line.substring(position + componentName.length);
+
+    // Class definition
+    if (new RegExp(`class\\s+${escapeRegex(componentName)}\\b`).test(line)) {
+        return ComponentReferenceType.ClassDefinition;
+    }
+
+    // Import statement
+    if (/import\s*{/.test(line) || /import\s+\w+/.test(line)) {
+        return ComponentReferenceType.Import;
+    }
+
+    // Export statement
+    if (/export\s*{/.test(line)) {
+        return ComponentReferenceType.Export;
+    }
+
+    // Entity methods
+    if (/\.addComponent\s*[(<]/.test(beforeText) || afterText.startsWith(')')) {
+        if (/\.addComponent\s*\(\s*$/.test(beforeText)) {
+            return ComponentReferenceType.EntityAddComponent;
+        }
+    }
+
+    if (/\.getComponent\s*[(<]/.test(beforeText)) {
+        return ComponentReferenceType.EntityGetComponent;
+    }
+
+    if (/\.hasComponent\s*[(<]/.test(beforeText)) {
+        return ComponentReferenceType.EntityHasComponent;
+    }
+
+    if (/\.removeComponent\s*[(<]/.test(beforeText)) {
+        return ComponentReferenceType.EntityRemoveComponent;
+    }
+
+    // System query definitions
+    if (/all\s*:\s*\[[^\]]*$/.test(beforeText)) {
+        return ComponentReferenceType.SystemQueryAll;
+    }
+
+    if (/any\s*:\s*\[[^\]]*$/.test(beforeText)) {
+        return ComponentReferenceType.SystemQueryAny;
+    }
+
+    if (/none\s*:\s*\[[^\]]*$/.test(beforeText)) {
+        return ComponentReferenceType.SystemQueryNone;
+    }
+
+    // Prefab definition (type: ComponentName)
+    if (/type\s*:\s*$/.test(beforeText)) {
+        return ComponentReferenceType.PrefabDefinition;
+    }
+
+    // Singleton methods
+    if (/\.setSingleton\s*[(<]/.test(beforeText)) {
+        return ComponentReferenceType.SingletonSet;
+    }
+
+    if (/\.getSingleton\s*[(<]/.test(beforeText)) {
+        return ComponentReferenceType.SingletonGet;
+    }
+
+    // Generic type parameters
+    if (/<\s*$/.test(beforeText) || /<[^>]*,\s*$/.test(beforeText)) {
+        return ComponentReferenceType.GenericParameter;
+    }
+
+    // Type annotation
+    if (/:\s*$/.test(beforeText) && !/=/.test(beforeText)) {
+        return ComponentReferenceType.TypeAnnotation;
+    }
+
+    // If component appears in system createSystem call
+    if (line.includes('createSystem')) {
+        return ComponentReferenceType.SystemQueryAll;
+    }
+
+    return null;
+}
+
+/**
+ * Creates workspace edits to rename a component
+ */
+export async function createRenameEdits(
+    oldName: string,
+    newName: string,
+    references: ComponentReference[]
+): Promise<vscode.WorkspaceEdit> {
+    const workspaceEdit = new vscode.WorkspaceEdit();
+
+    for (const ref of references) {
+        workspaceEdit.replace(ref.uri, ref.range, newName);
+    }
+
+    return workspaceEdit;
+}
+
+/**
+ * Groups references by file URI
+ */
+export function groupReferencesByFile(
+    references: ComponentReference[]
+): Map<string, ComponentReference[]> {
+    const grouped = new Map<string, ComponentReference[]>();
+
+    for (const ref of references) {
+        const key = ref.uri.toString();
+        const existing = grouped.get(key) || [];
+        existing.push(ref);
+        grouped.set(key, existing);
+    }
+
+    return grouped;
+}
+
+/**
+ * Gets a summary of component references
+ */
+export function summarizeReferences(references: ComponentReference[]): string {
+    const counts: Record<string, number> = {};
+
+    for (const ref of references) {
+        counts[ref.type] = (counts[ref.type] || 0) + 1;
+    }
+
+    const parts: string[] = [];
+
+    if (counts[ComponentReferenceType.ClassDefinition]) {
+        parts.push(`${counts[ComponentReferenceType.ClassDefinition]} definition(s)`);
+    }
+    if (counts[ComponentReferenceType.Import]) {
+        parts.push(`${counts[ComponentReferenceType.Import]} import(s)`);
+    }
+    if (counts[ComponentReferenceType.Export]) {
+        parts.push(`${counts[ComponentReferenceType.Export]} export(s)`);
+    }
+
+    const entityMethods =
+        (counts[ComponentReferenceType.EntityAddComponent] || 0) +
+        (counts[ComponentReferenceType.EntityGetComponent] || 0) +
+        (counts[ComponentReferenceType.EntityHasComponent] || 0) +
+        (counts[ComponentReferenceType.EntityRemoveComponent] || 0);
+    if (entityMethods) {
+        parts.push(`${entityMethods} entity method(s)`);
+    }
+
+    const queryRefs =
+        (counts[ComponentReferenceType.SystemQueryAll] || 0) +
+        (counts[ComponentReferenceType.SystemQueryAny] || 0) +
+        (counts[ComponentReferenceType.SystemQueryNone] || 0);
+    if (queryRefs) {
+        parts.push(`${queryRefs} system query/queries`);
+    }
+
+    if (counts[ComponentReferenceType.PrefabDefinition]) {
+        parts.push(`${counts[ComponentReferenceType.PrefabDefinition]} prefab(s)`);
+    }
+
+    const singletonRefs =
+        (counts[ComponentReferenceType.SingletonSet] || 0) +
+        (counts[ComponentReferenceType.SingletonGet] || 0);
+    if (singletonRefs) {
+        parts.push(`${singletonRefs} singleton reference(s)`);
+    }
+
+    return parts.join(', ');
+}
+
+/**
+ * Validates a component name
+ */
+export function isValidComponentName(name: string): boolean {
+    return /^[A-Z][a-zA-Z0-9]*$/.test(name);
+}
+
+/**
+ * Determines if a class name is likely a component (not a system, manager, etc.)
+ */
+export function isLikelyComponentClass(className: string): boolean {
+    const nonComponentPatterns = [
+        /System$/,
+        /Manager$/,
+        /Service$/,
+        /Controller$/,
+        /Provider$/,
+        /Factory$/,
+        /Builder$/,
+        /Handler$/,
+        /Plugin$/,
+        /Engine$/,
+        /Query$/,
+    ];
+
+    for (const pattern of nonComponentPatterns) {
+        if (pattern.test(className)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Escapes special regex characters
+ */
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Analyzes imports in a file to determine available components
+ */
+export async function analyzeFileImports(
+    document: vscode.TextDocument
+): Promise<{ name: string; source: string }[]> {
+    const imports: { name: string; source: string }[] = [];
+    const text = document.getText();
+
+    // Match import { A, B, C } from 'source'
+    const namedImportPattern = /import\s*{\s*([^}]+)\s*}\s*from\s*['"]([^'"]+)['"]/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = namedImportPattern.exec(text)) !== null) {
+        const names = match[1].split(',').map(
+            (n) =>
+                n
+                    .trim()
+                    .split(/\s+as\s+/)
+                    .pop()
+                    ?.trim() || ''
+        );
+        const source = match[2];
+
+        for (const name of names) {
+            if (name && /^[A-Z]/.test(name) && isLikelyComponentClass(name)) {
+                imports.push({ name, source });
+            }
+        }
+    }
+
+    // Match import DefaultExport from 'source'
+    const defaultImportPattern = /import\s+(\w+)\s+from\s*['"]([^'"]+)['"]/g;
+    while ((match = defaultImportPattern.exec(text)) !== null) {
+        const name = match[1];
+        const source = match[2];
+
+        if (/^[A-Z]/.test(name) && isLikelyComponentClass(name)) {
+            imports.push({ name, source });
+        }
+    }
+
+    return imports;
+}
+
+/**
+ * Gets all component classes defined in a file
+ */
+export function getComponentDefinitions(
+    document: vscode.TextDocument
+): { name: string; line: number }[] {
+    const components: { name: string; line: number }[] = [];
+    const text = document.getText();
+    const lines = text.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const match = line.match(/^(?:export\s+)?class\s+(\w+)/);
+
+        if (match && isLikelyComponentClass(match[1])) {
+            components.push({ name: match[1], line: i });
+        }
+    }
+
+    return components;
+}


### PR DESCRIPTION
This adds comprehensive refactoring capabilities to the VSCode extension:

Rename Component:
- ComponentRenameProvider for renaming component classes
- Updates all references across the workspace including:
  - Class definitions and imports
  - Entity methods (addComponent, getComponent, hasComponent, removeComponent)
  - System queries (all, any, none arrays)
  - Prefab definitions
  - Singleton methods

Extract Component:
- ExtractComponentCodeActionProvider for extracting properties
- Generates new component class with boilerplate
- Supports extracting to same file or new file
- Automatically adds import statements

Additional Commands:
- orion-ecs.renameComponent: Trigger rename at cursor
- orion-ecs.previewComponentReferences: Preview all references
- orion-ecs.moveComponentToFile: Move component to new file
- orion-ecs.extractComponent: Extract properties to new component

Also includes refactoring utilities for workspace-wide reference tracking and analysis.

Closes #300