### PR TITLE
feat: Add changesets for VS Code extension and ESLint plugin

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@orionecs/examples", "orionecs-tutorial-*", "orion-ecs-vscode"],
+  "ignore": ["@orionecs/examples", "orionecs-tutorial-*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/.changeset/eslint-component-types-rule.md
+++ b/.changeset/eslint-component-types-rule.md
@@ -1,0 +1,25 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add component-types ESLint rule for call-site validation
+
+Validates that types used as components are data-only classes without logic:
+- Detects methods, getters/setters, and arrow function properties
+- Uses TypeScript type checker for accurate type resolution
+- Works with external library types and type aliases
+- Validates at all ECS API call sites (addComponent, getComponent, etc.)
+
+Configurable Options:
+- `allowedMethods`: Whitelist specific methods (default: clone, reset, toString, toJSON, valueOf)
+- `excludePatterns`: Exclude specific type names from checking
+- `checkExternalTypes`: Validate types from node_modules (default: false)
+
+Coverage:
+- Entity methods (addComponent, getComponent, hasComponent, removeComponent)
+- System query definitions (all, any, none)
+- Singleton operations (setSingleton, getSingleton)
+- Prefab type definitions
+- Fluent query builder (withAll, withAny, withNone)
+
+Catches violations like using complex classes with business logic as components, enforcing the data-only component pattern.

--- a/.changeset/eslint-core-validation-rules.md
+++ b/.changeset/eslint-core-validation-rules.md
@@ -1,0 +1,32 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add core validation rules for ECS patterns
+
+Component Order Rule:
+- Validates component dependency ordering in prefabs and systems
+- Ensures dependencies are added before dependents
+- Detects circular dependencies between components
+- Supports registerComponentValidator dependencies
+- Works with prefab definitions and system queries
+
+Component Validator Rule:
+- Validates registerComponentValidator usage
+- Ensures validator functions have correct signatures
+- Detects missing or incorrect dependency specifications
+- Validates component class references in validators
+- Prevents common validation pattern mistakes
+
+Query Validator Rule:
+- Validates system query definitions (all, any, none)
+- Ensures query arrays contain valid component references
+- Detects duplicate components in queries
+- Warns about conflicting query constraints
+- Validates query structure and syntax
+
+Usage-Based Detection:
+- Automatically detects components from ECS API usage
+- Tracks addComponent, getComponent, hasComponent calls
+- No manual component registration required
+- Cross-file component detection via imports

--- a/.changeset/eslint-no-static-state.md
+++ b/.changeset/eslint-no-static-state.md
@@ -1,0 +1,29 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add no-static-state rule to prevent static state in ECS classes
+
+Detects and prevents static state in:
+- **Component classes**: Static properties/methods break entity isolation, interfere with serialization, and cause pooling issues
+- **System classes**: Static state creates hidden global state that violates ECS patterns
+- **Plugin classes**: Static state interferes with multi-engine scenarios and testing
+
+Detection Methods:
+- Pattern-based: Matches classes ending in 'Component', 'System', 'Plugin'
+- Interface-based: Detects classes implementing `EnginePlugin`
+- Usage-based: Tracks classes registered via `engine.use()` or `EngineBuilder.use()`
+
+Configurable Options:
+- `componentPattern`: Regex to identify component classes (default: 'Component$')
+- `systemPattern`: Regex to identify system classes (default: 'System$')
+- `pluginPattern`: Regex to identify plugin classes (default: 'Plugin$')
+- `detectFromUsage`: Detect from ECS API calls (default: true)
+- `checkComponents`: Enable component checking (default: true)
+- `checkSystems`: Enable system checking (default: true)
+- `checkPlugins`: Enable plugin checking (default: true)
+- `checkModuleLevelState`: Warn about module-level let/var (default: false)
+- `allowedStaticProperties`: Whitelist static properties like 'schema' or 'version'
+- `allowedModuleLevelPatterns`: Regex patterns for allowed module variables
+
+Encourages proper ECS patterns using singleton components or engine services instead of static state.

--- a/.changeset/eslint-phase-1-3-rules.md
+++ b/.changeset/eslint-phase-1-3-rules.md
@@ -1,0 +1,27 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add 15 new ESLint rules for ECS best practices (Phases 1-3)
+
+Phase 1 - Critical Safety Rules:
+- `no-query-in-act-callback`: Prevent expensive query creation inside system callbacks
+- `use-command-buffer-in-system`: Require command buffer for entity operations in systems
+- `subscription-cleanup-required`: Ensure plugin subscriptions are cleaned up in uninstall()
+
+Phase 2 - Correctness Rules:
+- `require-hasComponent-before-getComponent`: Require safety checks before component access
+- `singleton-mark-dirty`: Ensure singletons call markComponentDirty() after modifications
+- `no-async-in-system-callbacks`: Prevent async/await in system callbacks (breaks iteration)
+
+Phase 3 - Best Practice Rules:
+- `plugin-structure-validation`: Validate plugin class has name, version, and install()
+- `system-priority-explicit`: Require explicit system priority values
+- `component-lifecycle-complete`: Check onCreate/onDestroy callback pairing
+- `no-magic-tag-strings`: Discourage inline tag strings, prefer constants
+- `prefer-queueFree`: Prefer safe deferred deletion over immediate despawn
+- `system-naming-convention`: Enforce consistent system naming patterns
+- `plugin-logging-format`: Enforce structured logging in plugins
+- `no-nested-transactions`: Prevent nested command buffer execution errors
+
+Includes 227 comprehensive tests covering error cases, edge cases, and fix suggestions. Configured in both `recommended` and `strict` presets.

--- a/.changeset/eslint-phase-4-8-rules.md
+++ b/.changeset/eslint-phase-4-8-rules.md
@@ -1,0 +1,36 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add 13 advanced ESLint rules for ECS patterns (Phases 4-8)
+
+Phase 4 - Performance & Optimization Rules:
+- `prefer-batch-operations`: Encourage `commands.spawnBatch()` for bulk entity creation
+- `prefer-prefab-for-templates`: Suggest prefabs for repeated entity patterns
+- `prefer-component-pooling`: Recommend pooling for frequently created components
+- `query-specificity`: Ensure queries are specific and results are actually used
+
+Phase 5 - Entity & Hierarchy Rules:
+- `entity-unique-names`: Ensure entity names are unique for better debugging
+- `hierarchy-cycle-prevention`: Detect and prevent cycles in parent-child hierarchies
+
+Phase 6 - Advanced Plugin Rules:
+- `plugin-dependency-validation`: Validate plugin dependencies exist before use
+- `plugin-unbounded-collection`: Warn about unbounded collection growth in plugins
+- `plugin-context-cleanup`: Ensure proper context/engine cleanup in plugin uninstall()
+
+Phase 7 - Reactive Programming Rules:
+- `mark-component-dirty`: Ensure `markComponentDirty()` is called after component modifications
+- `use-watchComponents-filter`: Encourage filtered component watching for performance
+
+Phase 8 - Type Safety & Physics Rules:
+- `component-default-params`: Suggest default parameter values in component constructors
+- `fixed-update-for-physics`: Require physics systems use `fixedUpdate` for determinism
+
+All rules include:
+- Comprehensive test coverage (217 new tests, 444 total passing)
+- Fix suggestions where applicable
+- Configurable severity levels
+- Detailed documentation with examples
+
+Brings total ESLint plugin rule count to 28 comprehensive rules for ECS development.

--- a/.changeset/eslint-prefer-engine-logger.md
+++ b/.changeset/eslint-prefer-engine-logger.md
@@ -1,0 +1,24 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add prefer-engine-logger rule to encourage secure logging
+
+Discourages `console.*` statements in favor of the engine's built-in logger which provides:
+- Automatic sanitization to prevent log injection attacks
+- Tagged logging for better organization and filtering
+- Configurable log levels (debug, info, warn, error)
+- Consistent formatting across the application
+- Integration with engine lifecycle and debugging tools
+
+Rule Options:
+- `methods`: Array of console methods to flag (default: all logging methods)
+- `allowInTests`: Allow console.* in test files (default: true)
+- `allowConsoleError`: Allow console.error for critical unrecoverable errors (default: true)
+
+Provides contextual error messages:
+- System callbacks: "Use engine.logger or system-specific logger"
+- Plugin code: "Use this.logger from PluginContext"
+- General code: "Use engine.logger for consistent logging"
+
+Includes auto-fix suggestions to replace console.log with appropriate logger calls based on context.

--- a/.changeset/eslint-typescript-type-aware.md
+++ b/.changeset/eslint-typescript-type-aware.md
@@ -1,0 +1,25 @@
+---
+"@orion-ecs/eslint-plugin-ecs": minor
+---
+
+Add TypeScript type-aware linting for cross-file component resolution
+
+TypeScript Integration:
+- Enable type-checking in ESLint rules via `project` option
+- Resolve component types across files and packages
+- Support for type aliases and renamed imports
+- External package type resolution via TypeScript compiler API
+
+Type Resolution Utilities:
+- `resolveTypeInfo()`: Resolve types including imports and type aliases
+- `resolveComponentType()`: Get component class from type references
+- `isValidComponentClass()`: Validate component class structure
+- Cross-file type tracking for dependency analysis
+
+Enhanced Rules:
+- Component-order rule now resolves imported component types
+- Component-validator rule validates cross-file validators
+- Support for components from external @orion-ecs packages
+- Proper handling of re-exported types
+
+This enables comprehensive validation of component dependencies and usage patterns even when components are defined in different files or external packages.

--- a/.changeset/vscode-code-navigation.md
+++ b/.changeset/vscode-code-navigation.md
@@ -1,0 +1,27 @@
+---
+"orion-ecs-vscode": minor
+---
+
+Add enhanced code navigation (Go to Definition, Find References)
+
+Go to Definition Support:
+- Jump to component class definitions from any usage
+- Navigate to system definitions from getSystem() calls
+- Find prefab definitions from createFromPrefab() calls
+- Context-aware detection (query arrays, entity methods, singletons)
+- Works across TypeScript and JavaScript files
+
+Find All References:
+- Find all component references with context categorization
+- Locate system references across workspace
+- Track prefab usage throughout codebase
+- Results displayed in peek view or references panel
+- Distinguishes between definitions, imports, and usage
+
+Enhanced Commands:
+- `orion-ecs.findComponentReferences`: Find component usage
+- `orion-ecs.findSystemReferences`: Find system usage
+- `orion-ecs.findPrefabReferences`: Find prefab usage
+- `orion-ecs.goToDefinition`: Jump to ECS element definition
+
+Includes comprehensive test coverage for navigation providers and context detection logic.

--- a/.changeset/vscode-debugging-tools.md
+++ b/.changeset/vscode-debugging-tools.md
@@ -1,0 +1,27 @@
+---
+"orion-ecs-vscode": minor
+---
+
+Add debugging tools (Entity Inspector, System Visualizer)
+
+Entity Inspector Panel:
+- WebView panel for deep entity inspection
+- Live component data visualization with JSON formatting
+- Tag list display and management
+- Parent/child hierarchy navigation
+- Real-time updates via debug bridge
+- Demo mode for testing without live engine
+
+System Visualizer Panel:
+- Comprehensive system performance analysis
+- Execution time tracking and profiling
+- Query match statistics (entities processed per update)
+- System priority visualization
+- Enable/disable system controls
+- Sortable by execution time or priority
+
+Debug Bridge:
+- WebSocket-based communication between extension and engine
+- Entity snapshot protocol for live inspection
+- System profiling data aggregation
+- Extensible command/response architecture

--- a/.changeset/vscode-initial-extension.md
+++ b/.changeset/vscode-initial-extension.md
@@ -1,0 +1,21 @@
+---
+"orion-ecs-vscode": minor
+---
+
+Add comprehensive VS Code extension for OrionECS development
+
+Core Features:
+- Component Tree View: Browse all components in your workspace with CodeLens integration
+- System Tree View: View and manage systems with enable/disable toggles
+- Entity Tree View: Inspect runtime entities with real-time updates
+- Auto-completion: IntelliSense for component names, system names, and prefabs
+- Hover Information: Rich tooltips for components and systems with metadata
+- Diagnostics: Real-time validation of component usage and system definitions
+
+Code Intelligence:
+- Syntax highlighting for ECS patterns
+- Component snippet generators
+- System callback template completion
+- Prefab definition scaffolding
+
+The extension integrates with OrionECS runtime via debug protocol for live entity inspection.

--- a/.changeset/vscode-refactoring-support.md
+++ b/.changeset/vscode-refactoring-support.md
@@ -1,0 +1,31 @@
+---
+"orion-ecs-vscode": minor
+---
+
+Add refactoring support for ECS components
+
+Rename Component:
+- ComponentRenameProvider for intelligent component renaming
+- Workspace-wide reference updates including:
+  - Class definitions and imports
+  - Entity methods (addComponent, getComponent, hasComponent, removeComponent)
+  - System queries (all, any, none arrays)
+  - Prefab type definitions
+  - Singleton method calls
+- Preview changes before applying
+- Maintains code consistency across all files
+
+Extract Component:
+- ExtractComponentCodeActionProvider for property extraction
+- Generate new component classes from selected properties
+- Automatic boilerplate generation (constructor, TypeScript types)
+- Option to extract to same file or new file
+- Auto-import statements for new components
+
+Additional Refactoring Commands:
+- `orion-ecs.renameComponent`: Trigger rename operation at cursor
+- `orion-ecs.previewComponentReferences`: Preview all component references
+- `orion-ecs.moveComponentToFile`: Move component class to new file
+- `orion-ecs.extractComponent`: Extract properties to new component class
+
+Includes refactoring utilities for workspace-wide reference tracking and analysis.

--- a/.changeset/vscode-visualization-tools.md
+++ b/.changeset/vscode-visualization-tools.md
@@ -1,0 +1,36 @@
+---
+"orion-ecs-vscode": minor
+---
+
+Add visualization tools (Entity Hierarchy Tree, Archetype Visualizer)
+
+Entity Hierarchy Tree:
+- New EntityHierarchyTreeProvider for runtime hierarchy visualization
+- Parent-child relationship tree with expand/collapse navigation
+- Component count and tag information per entity
+- Interactive selection with Entity Inspector integration
+- Real-time updates via debug bridge
+- Visual indicators for entity state and composition
+
+Archetype Visualizer Panel:
+- WebView panel displaying all engine archetypes
+- Component composition breakdown per archetype
+- Entity count statistics per archetype
+- Performance metrics:
+  - Cache hit rate tracking
+  - Memory consumption per archetype
+  - Query match efficiency
+- Sortable views (by entity count, memory, component count)
+- Color-coded memory usage indicators
+- Demo mode with simulated archetype data
+
+Enhanced Debug Protocol:
+- ArchetypeSnapshot type for archetype metadata
+- Memory profiling data structures
+- Performance statistics aggregation
+- Extended debug bridge commands for visualization
+
+New Commands:
+- `orion-ecs.showEntityHierarchy`: Open hierarchy tree view
+- `orion-ecs.showArchetypeVisualizer`: Open archetype panel
+- `orion-ecs.refreshHierarchy`: Refresh hierarchy data

--- a/packages/eslint-plugin-ecs/package.json
+++ b/packages/eslint-plugin-ecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orion-ecs/eslint-plugin-ecs",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "ESLint rules for enforcing ECS best practices in OrionECS projects",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "orion-ecs-vscode",
   "displayName": "OrionECS",
   "description": "VS Code extension for OrionECS - Entity Component System framework with snippets, IntelliSense, and developer tools",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "publisher": "orion-ecs",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

Add comprehensive changesets documenting all features for the initial **0.1.0** releases of the VS Code extension and ESLint plugin.

## New Packages

### orion-ecs-vscode (0.1.0)

**5 Changesets:**
- Initial extension with tree views, IntelliSense, and diagnostics
- Debugging tools (Entity Inspector, System Visualizer)  
- Code navigation (Go to Definition, Find References)
- Refactoring support (rename, extract components)
- Visualization tools (Entity Hierarchy, Archetype Visualizer)

### @orion-ecs/eslint-plugin-ecs (0.1.0)

**7 Changesets:**
- Core validation rules (component-order, component-validator, query-validator)
- TypeScript type-aware linting for cross-file resolution
- Component-types rule for data-only validation
- 15 safety, correctness, and best practice rules (Phases 1-3)
- Prefer-engine-logger rule for secure logging
- No-static-state rule for components/systems/plugins
- 13 advanced rules for performance and patterns (Phases 4-8)

**Total: 28 ESLint rules** covering the complete ECS development workflow

## Changes

- Added 12 changeset files documenting all features
- Set both packages to 0.0.0 → changesets will bump to 0.1.0
- Removed `orion-ecs-vscode` from changeset ignore list
- Both packages ready for first npm publication

## Test Plan

- [x] Verify changeset status shows correct versions (0.1.0)
- [x] Confirm both packages not yet published to npm
- [x] All changesets properly formatted with package names
- [ ] Review changeset content for accuracy
- [ ] Merge and verify Version Packages PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)