### PR TITLE
fix(workflow): Prevent shell escaping issues in nightly code review

### DIFF
--- a/.github/workflows/claude-nightly-review.yml
+++ b/.github/workflows/claude-nightly-review.yml
@@ -209,6 +209,13 @@ jobs:
                  - Code snippet if helpful
                - Metrics summary (files reviewed, issues found by category)
 
+            **IMPORTANT - How to Create the Issue:**
+            To avoid shell escaping issues with backticks and code blocks:
+            1. Use the `Write` tool to create a file (e.g., `review-report.md`) with the full markdown report
+            2. Use `gh issue create --title "🔍 [Type] Code Review - [DATE]" --label "code-review,automated" --body-file review-report.md`
+            3. DO NOT try to embed markdown with code blocks directly in the command
+            4. Always use `--body-file` for the report content
+
             ## Guidelines
 
             - **CRITICAL**: Prioritize type safety violations above all else - this is a type-safe framework
@@ -229,7 +236,7 @@ jobs:
             - `packages/*/src/` - Supporting packages
             - `examples/` - Example code (check for anti-patterns that users might copy)
 
-          claude_args: '--allowed-tools "Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh label create:*)"'
+          claude_args: '--allowed-tools "Write,Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh label create:*)"'
 
       - name: Ensure labels exist
         if: steps.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

Fixes shell escaping errors in the nightly code review workflow by instructing Claude to use a file-based approach instead of embedding markdown directly in commands.

## Problem

The workflow was failing with errors like:
- `Error: Command contains backticks for command substitution`
- `Error: This command uses shell operators that require approval for safety`

This happened when Claude tried to create GitHub issues with markdown content containing code blocks and backticks directly in `gh issue create --body "..."` commands.

## Solution

1. **Added explicit instructions** for Claude to:
   - Use the `Write` tool to create a markdown file (e.g., `review-report.md`)
   - Use `gh issue create --body-file review-report.md` instead of `--body "..."`
   - Never embed markdown with code blocks directly in commands

2. **Enabled Write tool** in `claude_args` allowed-tools list

## Changes

- `.github/workflows/claude-nightly-review.yml`:
  - Added "**IMPORTANT - How to Create the Issue:**" section with step-by-step instructions
  - Added `Write` to allowed tools: `--allowed-tools "Write,Bash(gh issue create:*),..."`

## Testing

Manual test confirmed the file-based approach works:
- Created `review-comment.md` with code blocks and backticks
- Successfully posted to issue #286 using `gh issue comment --body-file`
- No escaping errors

## Impact

- Nightly code review workflow will now complete successfully
- Detailed reports with code snippets will post without errors
- No changes to report format or content, just the delivery mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)