### PR TITLE
feat: Build project scaffolding tools

### DIFF
--- a/.changeset/create-package-scaffolding.md
+++ b/.changeset/create-package-scaffolding.md
@@ -1,0 +1,22 @@
+---
+"@orion-ecs/create": minor
+---
+
+Add @orion-ecs/create package for project scaffolding
+
+New CLI tool to quickly scaffold OrionECS game projects with a single command.
+
+Features:
+- Interactive project setup wizard with prompts for configuration
+- Multiple project templates: vanilla, canvas2d, pixi, three, multiplayer, vite, webpack
+- TypeScript and JavaScript language support
+- Package manager selection (npm, yarn, pnpm)
+- Automatic git initialization and dependency installation
+- Complete project structure with components, systems, and engine setup
+
+Usage:
+```bash
+npm create @orion-ecs my-game
+npm create @orion-ecs my-game -t pixi
+npm create @orion-ecs my-game -t three --skip-install
+```

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ publish/
 
 # Allow our monorepo packages
 !/packages/core/
+!/packages/create/
 !/packages/math/
 !/packages/graphics/
 !/packages/plugin-api/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "workspaces": [
         "packages/core",
+        "packages/create",
         "packages/math",
         "packages/graphics",
         "packages/plugin-api",
@@ -5206,6 +5207,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@orion-ecs/create": {
+      "resolved": "packages/create",
+      "link": true
+    },
     "node_modules/@orion-ecs/debug-visualizer": {
       "resolved": "plugins/debug-visualizer",
       "link": true
@@ -5993,6 +5998,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -11341,6 +11357,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12527,7 +12552,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -12816,6 +12840,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -13280,6 +13317,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -15479,6 +15522,49 @@
         "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "^5.9.3"
       }
+    },
+    "packages/create": {
+      "name": "@orion-ecs/create",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "create-orion-app": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.7",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^22.14.0",
+        "@types/prompts": "^2.4.9",
+        "jest": "30.2.0",
+        "oxlint": "^1.29.0",
+        "ts-jest": "^29.4.5",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/create/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/create/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/eslint-plugin-ecs": {
       "name": "@orion-ecs/eslint-plugin-ecs",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "workspaces": [
     "packages/core",
+    "packages/create",
     "packages/math",
     "packages/graphics",
     "packages/plugin-api",

--- a/packages/create/biome.json
+++ b/packages/create/biome.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
+  "extends": ["../../biome.json"],
+  "vcs": {
+    "enabled": false
+  }
+}

--- a/packages/create/jest.config.js
+++ b/packages/create/jest.config.js
@@ -1,0 +1,20 @@
+/** @type {import('jest').Config} */
+export default {
+    preset: 'ts-jest/presets/default-esm',
+    testEnvironment: 'node',
+    roots: ['<rootDir>/src'],
+    testMatch: ['**/__tests__/**/*.test.ts'],
+    moduleNameMapper: {
+        '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
+    transform: {
+        '^.+\\.tsx?$': [
+            'ts-jest',
+            {
+                useESM: true,
+            },
+        ],
+    },
+    extensionsToTreatAsEsm: ['.ts'],
+    collectCoverageFrom: ['src/**/*.ts', '!src/**/__tests__/**', '!src/cli.ts'],
+};

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@orion-ecs/create",
+  "version": "0.1.0",
+  "description": "Create OrionECS projects with a single command",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "create-orion-app": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "jest",
+    "lint": "oxlint src",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run typecheck && npm run lint && npm run format:check",
+    "clean": "rm -rf dist coverage .turbo"
+  },
+  "keywords": [
+    "orion-ecs",
+    "ecs",
+    "entity-component-system",
+    "game-development",
+    "cli",
+    "scaffolding",
+    "create"
+  ],
+  "author": {
+    "name": "Tyler Coles",
+    "email": "tyevco@gmail.com"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tyevco/orionecs"
+  },
+  "bugs": {
+    "url": "https://github.com/tyevco/orionecs/issues"
+  },
+  "homepage": "https://github.com/tyevco/orionecs#readme",
+  "dependencies": {
+    "picocolors": "^1.1.1",
+    "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.7",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.14.0",
+    "@types/prompts": "^2.4.9",
+    "jest": "30.2.0",
+    "oxlint": "^1.29.0",
+    "ts-jest": "^29.4.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "templates"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/create/src/__tests__/args.test.ts
+++ b/packages/create/src/__tests__/args.test.ts
@@ -1,0 +1,78 @@
+import { parseArgs } from '../args.js';
+
+describe('parseArgs', () => {
+    it('should parse project name', () => {
+        const result = parseArgs(['my-project']);
+        expect(result.projectName).toBe('my-project');
+    });
+
+    it('should parse help flag', () => {
+        expect(parseArgs(['-h']).help).toBe(true);
+        expect(parseArgs(['--help']).help).toBe(true);
+    });
+
+    it('should parse version flag', () => {
+        expect(parseArgs(['-v']).version).toBe(true);
+        expect(parseArgs(['--version']).version).toBe(true);
+    });
+
+    it('should parse yes flag', () => {
+        expect(parseArgs(['-y']).yes).toBe(true);
+        expect(parseArgs(['--yes']).yes).toBe(true);
+    });
+
+    it('should parse skip-install flag', () => {
+        expect(parseArgs(['--skip-install']).skipInstall).toBe(true);
+    });
+
+    it('should parse skip-git flag', () => {
+        expect(parseArgs(['--skip-git']).skipGit).toBe(true);
+    });
+
+    it('should parse javascript flag', () => {
+        expect(parseArgs(['--javascript']).javascript).toBe(true);
+        expect(parseArgs(['--js']).javascript).toBe(true);
+    });
+
+    it('should parse template option', () => {
+        expect(parseArgs(['-t', 'pixi']).template).toBe('pixi');
+        expect(parseArgs(['--template', 'three']).template).toBe('three');
+    });
+
+    it('should ignore invalid template', () => {
+        expect(parseArgs(['-t', 'invalid']).template).toBeUndefined();
+    });
+
+    it('should parse package-manager option', () => {
+        expect(parseArgs(['-p', 'yarn']).packageManager).toBe('yarn');
+        expect(parseArgs(['--package-manager', 'pnpm']).packageManager).toBe('pnpm');
+    });
+
+    it('should ignore invalid package manager', () => {
+        expect(parseArgs(['-p', 'invalid']).packageManager).toBeUndefined();
+    });
+
+    it('should handle multiple options', () => {
+        const result = parseArgs([
+            'my-game',
+            '-t',
+            'canvas2d',
+            '-p',
+            'yarn',
+            '--skip-install',
+            '-y',
+        ]);
+
+        expect(result.projectName).toBe('my-game');
+        expect(result.template).toBe('canvas2d');
+        expect(result.packageManager).toBe('yarn');
+        expect(result.skipInstall).toBe(true);
+        expect(result.yes).toBe(true);
+    });
+
+    it('should return empty options for empty args', () => {
+        const result = parseArgs([]);
+        expect(result.projectName).toBeUndefined();
+        expect(result.template).toBeUndefined();
+    });
+});

--- a/packages/create/src/__tests__/template-files.test.ts
+++ b/packages/create/src/__tests__/template-files.test.ts
@@ -1,0 +1,265 @@
+import { generateTemplateFiles } from '../template-files.js';
+import type { ProjectConfig, TemplateType, TemplateFile } from '../types.js';
+
+function createConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+    return {
+        name: 'test-project',
+        template: 'vanilla',
+        language: 'typescript',
+        packageManager: 'npm',
+        installDeps: false,
+        initGit: false,
+        ...overrides,
+    };
+}
+
+function findFile(files: TemplateFile[], path: string): TemplateFile {
+    const file = files.find((f) => f.path === path);
+    if (!file) {
+        throw new Error(`File not found: ${path}`);
+    }
+    return file;
+}
+
+describe('generateTemplateFiles', () => {
+    describe('common files', () => {
+        it('should generate package.json', () => {
+            const config = createConfig();
+            const files = generateTemplateFiles(config);
+            const packageJson = findFile(files, 'package.json');
+
+            const parsed = JSON.parse(packageJson.content);
+            expect(parsed.name).toBe('test-project');
+            expect(parsed.dependencies['@orion-ecs/core']).toBeDefined();
+        });
+
+        it('should generate .gitignore', () => {
+            const config = createConfig();
+            const files = generateTemplateFiles(config);
+            const gitignore = findFile(files, '.gitignore');
+
+            expect(gitignore.content).toContain('node_modules');
+            expect(gitignore.content).toContain('dist');
+        });
+
+        it('should generate README.md', () => {
+            const config = createConfig();
+            const files = generateTemplateFiles(config);
+            const readme = findFile(files, 'README.md');
+
+            expect(readme.content).toContain('test-project');
+        });
+
+        it('should generate tsconfig.json for TypeScript projects', () => {
+            const config = createConfig({ language: 'typescript' });
+            const files = generateTemplateFiles(config);
+            const tsconfig = findFile(files, 'tsconfig.json');
+
+            const parsed = JSON.parse(tsconfig.content);
+            expect(parsed.compilerOptions.strict).toBe(true);
+        });
+
+        it('should not generate tsconfig.json for JavaScript projects', () => {
+            const config = createConfig({ language: 'javascript' });
+            const files = generateTemplateFiles(config);
+
+            const tsconfig = files.find((f) => f.path === 'tsconfig.json');
+            expect(tsconfig).toBeUndefined();
+        });
+    });
+
+    describe('vanilla template', () => {
+        it('should generate entry point', () => {
+            const config = createConfig({ template: 'vanilla' });
+            const files = generateTemplateFiles(config);
+            const entry = findFile(files, 'src/index.ts');
+
+            expect(entry.content).toContain('EngineBuilder');
+        });
+
+        it('should generate components', () => {
+            const config = createConfig({ template: 'vanilla' });
+            const files = generateTemplateFiles(config);
+            const components = findFile(files, 'src/components/transform.ts');
+
+            expect(components.content).toContain('class Position');
+            expect(components.content).toContain('class Velocity');
+        });
+
+        it('should generate systems', () => {
+            const config = createConfig({ template: 'vanilla' });
+            const files = generateTemplateFiles(config);
+            const movement = findFile(files, 'src/systems/movement.ts');
+
+            expect(movement.content).toContain('MovementSystem');
+        });
+    });
+
+    describe('canvas2d template', () => {
+        it('should generate index.html', () => {
+            const config = createConfig({ template: 'canvas2d' });
+            const files = generateTemplateFiles(config);
+            const html = findFile(files, 'index.html');
+
+            expect(html.content).toContain('canvas');
+        });
+
+        it('should generate vite.config.ts', () => {
+            const config = createConfig({ template: 'canvas2d' });
+            const files = generateTemplateFiles(config);
+            const viteConfig = findFile(files, 'vite.config.ts');
+
+            expect(viteConfig.content).toContain('defineConfig');
+        });
+
+        it('should generate render system', () => {
+            const config = createConfig({ template: 'canvas2d' });
+            const files = generateTemplateFiles(config);
+            const render = findFile(files, 'src/systems/render.ts');
+
+            expect(render.content).toContain('RenderSystem');
+        });
+    });
+
+    describe('pixi template', () => {
+        it('should include pixi.js dependency', () => {
+            const config = createConfig({ template: 'pixi' });
+            const files = generateTemplateFiles(config);
+            const packageJson = findFile(files, 'package.json');
+
+            const parsed = JSON.parse(packageJson.content);
+            expect(parsed.dependencies['pixi.js']).toBeDefined();
+        });
+
+        it('should generate PixiRenderable component', () => {
+            const config = createConfig({ template: 'pixi' });
+            const files = generateTemplateFiles(config);
+            const components = findFile(files, 'src/components/transform.ts');
+
+            expect(components.content).toContain('PixiRenderable');
+        });
+    });
+
+    describe('three template', () => {
+        it('should include three dependency', () => {
+            const config = createConfig({ template: 'three' });
+            const files = generateTemplateFiles(config);
+            const packageJson = findFile(files, 'package.json');
+
+            const parsed = JSON.parse(packageJson.content);
+            expect(parsed.dependencies['three']).toBeDefined();
+        });
+
+        it('should generate 3D components', () => {
+            const config = createConfig({ template: 'three' });
+            const files = generateTemplateFiles(config);
+            const components = findFile(files, 'src/components/transform.ts');
+
+            expect(components.content).toContain('Position3D');
+            expect(components.content).toContain('ThreeRenderable');
+        });
+    });
+
+    describe('multiplayer template', () => {
+        it('should include ws dependency', () => {
+            const config = createConfig({ template: 'multiplayer' });
+            const files = generateTemplateFiles(config);
+            const packageJson = findFile(files, 'package.json');
+
+            const parsed = JSON.parse(packageJson.content);
+            expect(parsed.dependencies['ws']).toBeDefined();
+        });
+
+        it('should generate server file', () => {
+            const config = createConfig({ template: 'multiplayer' });
+            const files = generateTemplateFiles(config);
+            const server = findFile(files, 'src/server.ts');
+
+            expect(server.content).toContain('WebSocketServer');
+        });
+
+        it('should generate client file', () => {
+            const config = createConfig({ template: 'multiplayer' });
+            const files = generateTemplateFiles(config);
+            const client = findFile(files, 'src/client.ts');
+
+            expect(client.content).toContain('WebSocket');
+        });
+
+        it('should generate shared components', () => {
+            const config = createConfig({ template: 'multiplayer' });
+            const files = generateTemplateFiles(config);
+            const shared = findFile(files, 'src/shared/components.ts');
+
+            expect(shared.content).toContain('NetworkId');
+        });
+    });
+
+    describe('webpack template', () => {
+        it('should include webpack dependencies', () => {
+            const config = createConfig({ template: 'webpack' });
+            const files = generateTemplateFiles(config);
+            const packageJson = findFile(files, 'package.json');
+
+            const parsed = JSON.parse(packageJson.content);
+            expect(parsed.devDependencies['webpack']).toBeDefined();
+            expect(parsed.devDependencies['webpack-cli']).toBeDefined();
+        });
+
+        it('should generate webpack.config.ts', () => {
+            const config = createConfig({ template: 'webpack' });
+            const files = generateTemplateFiles(config);
+            const webpackConfig = findFile(files, 'webpack.config.ts');
+
+            expect(webpackConfig.content).toContain('HtmlWebpackPlugin');
+        });
+    });
+
+    describe('JavaScript output', () => {
+        it('should use .js extensions', () => {
+            const config = createConfig({ template: 'vanilla', language: 'javascript' });
+            const files = generateTemplateFiles(config);
+            const entry = findFile(files, 'src/index.js');
+
+            expect(entry).toBeDefined();
+        });
+
+        it('should not include type annotations', () => {
+            const config = createConfig({ template: 'vanilla', language: 'javascript' });
+            const files = generateTemplateFiles(config);
+            const entry = findFile(files, 'src/index.js');
+
+            // JavaScript files should have simpler constructor params
+            expect(entry.content).not.toContain(': number');
+        });
+    });
+
+    describe('all templates', () => {
+        const allTemplates: TemplateType[] = [
+            'vanilla',
+            'canvas2d',
+            'pixi',
+            'three',
+            'multiplayer',
+            'vite',
+            'webpack',
+        ];
+
+        for (const template of allTemplates) {
+            it(`should generate valid files for ${template} template`, () => {
+                const config = createConfig({ template });
+                const files = generateTemplateFiles(config);
+
+                // Should have at least package.json, .gitignore, README
+                expect(files.length).toBeGreaterThanOrEqual(3);
+
+                // All paths should be valid
+                for (const file of files) {
+                    expect(file.path).toBeTruthy();
+                    expect(file.content).toBeTruthy();
+                    expect(file.path).not.toContain('undefined');
+                }
+            });
+        }
+    });
+});

--- a/packages/create/src/__tests__/templates.test.ts
+++ b/packages/create/src/__tests__/templates.test.ts
@@ -1,0 +1,84 @@
+import { templates, getTemplateInfo, getTemplateChoices, isValidTemplate } from '../templates.js';
+import type { TemplateType } from '../types.js';
+
+describe('templates', () => {
+    describe('templates object', () => {
+        it('should have all expected templates', () => {
+            const expectedTemplates: TemplateType[] = [
+                'vanilla',
+                'canvas2d',
+                'pixi',
+                'three',
+                'multiplayer',
+                'vite',
+                'webpack',
+            ];
+
+            for (const template of expectedTemplates) {
+                expect(templates[template]).toBeDefined();
+            }
+        });
+
+        it('should have required properties for each template', () => {
+            for (const [id, template] of Object.entries(templates)) {
+                expect(template.id).toBe(id);
+                expect(template.name).toBeTruthy();
+                expect(template.description).toBeTruthy();
+                expect(template.dependencies).toBeDefined();
+                expect(template.devDependencies).toBeDefined();
+                expect(template.tags).toBeInstanceOf(Array);
+            }
+        });
+
+        it('should include @orion-ecs/core in all template dependencies', () => {
+            for (const template of Object.values(templates)) {
+                expect(template.dependencies['@orion-ecs/core']).toBeDefined();
+            }
+        });
+    });
+
+    describe('getTemplateInfo', () => {
+        it('should return template info for valid template', () => {
+            const info = getTemplateInfo('vanilla');
+            expect(info).toBeDefined();
+            expect(info?.id).toBe('vanilla');
+            expect(info?.name).toBe('Vanilla');
+        });
+
+        it('should return undefined for invalid template', () => {
+            const info = getTemplateInfo('invalid' as TemplateType);
+            expect(info).toBeUndefined();
+        });
+    });
+
+    describe('getTemplateChoices', () => {
+        it('should return array of choices', () => {
+            const choices = getTemplateChoices();
+            expect(Array.isArray(choices)).toBe(true);
+            expect(choices.length).toBe(Object.keys(templates).length);
+        });
+
+        it('should have title, value, and description for each choice', () => {
+            const choices = getTemplateChoices();
+            for (const choice of choices) {
+                expect(choice.title).toBeTruthy();
+                expect(choice.value).toBeTruthy();
+                expect(choice.description).toBeTruthy();
+            }
+        });
+    });
+
+    describe('isValidTemplate', () => {
+        it('should return true for valid templates', () => {
+            expect(isValidTemplate('vanilla')).toBe(true);
+            expect(isValidTemplate('pixi')).toBe(true);
+            expect(isValidTemplate('three')).toBe(true);
+        });
+
+        it('should return false for invalid templates', () => {
+            expect(isValidTemplate('invalid')).toBe(false);
+            expect(isValidTemplate('')).toBe(false);
+            expect(isValidTemplate('VANILLA')).toBe(false);
+        });
+    });
+});

--- a/packages/create/src/args.ts
+++ b/packages/create/src/args.ts
@@ -1,0 +1,62 @@
+import type { CliOptions, TemplateType } from './types.js';
+import { isValidTemplate } from './templates.js';
+
+/**
+ * Parse command line arguments
+ */
+export function parseArgs(args: string[]): CliOptions {
+    const options: CliOptions = {};
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        // Handle flags
+        if (arg.startsWith('-')) {
+            switch (arg) {
+                case '-h':
+                case '--help':
+                    options.help = true;
+                    break;
+                case '-v':
+                case '--version':
+                    options.version = true;
+                    break;
+                case '-y':
+                case '--yes':
+                    options.yes = true;
+                    break;
+                case '--skip-install':
+                    options.skipInstall = true;
+                    break;
+                case '--skip-git':
+                    options.skipGit = true;
+                    break;
+                case '--javascript':
+                case '--js':
+                    options.javascript = true;
+                    break;
+                case '-t':
+                case '--template': {
+                    const templateArg = args[++i];
+                    if (templateArg && isValidTemplate(templateArg)) {
+                        options.template = templateArg as TemplateType;
+                    }
+                    break;
+                }
+                case '-p':
+                case '--package-manager': {
+                    const pm = args[++i];
+                    if (pm === 'npm' || pm === 'yarn' || pm === 'pnpm') {
+                        options.packageManager = pm;
+                    }
+                    break;
+                }
+            }
+        } else if (!options.projectName) {
+            // First non-flag argument is the project name
+            options.projectName = arg;
+        }
+    }
+
+    return options;
+}

--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+ * @orion-ecs/create CLI
+ *
+ * Create OrionECS projects with a single command:
+ *   npm create @orion-ecs
+ *   npx @orion-ecs/create my-game
+ */
+
+import pc from 'picocolors';
+import { parseArgs } from './args.js';
+import { runPrompts } from './prompts.js';
+import { createProject } from './generator.js';
+import { printHelp, printVersion, printBanner } from './help.js';
+
+async function main(): Promise<void> {
+    const options = parseArgs(process.argv.slice(2));
+
+    // Handle help and version flags
+    if (options.help) {
+        printHelp();
+        process.exit(0);
+    }
+
+    if (options.version) {
+        printVersion();
+        process.exit(0);
+    }
+
+    // Print banner
+    printBanner();
+
+    // Run interactive prompts
+    const config = await runPrompts(options);
+
+    if (!config) {
+        console.log(pc.red('Failed to gather project configuration.'));
+        process.exit(1);
+    }
+
+    // Create the project
+    const success = await createProject(config);
+
+    if (!success) {
+        process.exit(1);
+    }
+}
+
+main().catch((error) => {
+    console.error(pc.red('Unexpected error:'));
+    console.error(error);
+    process.exit(1);
+});

--- a/packages/create/src/generator.ts
+++ b/packages/create/src/generator.ts
@@ -1,0 +1,120 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import pc from 'picocolors';
+import type { ProjectConfig } from './types.js';
+import { getTemplateInfo } from './templates.js';
+import { generateTemplateFiles } from './template-files.js';
+
+/**
+ * Create a new OrionECS project
+ */
+export async function createProject(config: ProjectConfig): Promise<boolean> {
+    const targetDir = config.targetDir || config.name;
+    const projectPath = path.resolve(process.cwd(), targetDir);
+
+    console.log();
+    console.log(pc.cyan(`Creating project in ${pc.bold(projectPath)}...`));
+    console.log();
+
+    // Check if directory already exists
+    if (fs.existsSync(projectPath)) {
+        const files = fs.readdirSync(projectPath);
+        if (files.length > 0) {
+            console.log(pc.red(`Error: Directory ${targetDir} is not empty.`));
+            console.log(pc.dim('Please choose a different name or delete the directory.'));
+            return false;
+        }
+    } else {
+        fs.mkdirSync(projectPath, { recursive: true });
+    }
+
+    // Get template info
+    const templateInfo = getTemplateInfo(config.template);
+    if (!templateInfo) {
+        console.log(pc.red(`Error: Unknown template "${config.template}"`));
+        return false;
+    }
+
+    try {
+        // Generate template files
+        console.log(pc.dim('Generating project files...'));
+        const files = generateTemplateFiles(config);
+
+        for (const file of files) {
+            const filePath = path.join(projectPath, file.path);
+            const fileDir = path.dirname(filePath);
+
+            // Create directory if needed
+            if (!fs.existsSync(fileDir)) {
+                fs.mkdirSync(fileDir, { recursive: true });
+            }
+
+            // Write file
+            fs.writeFileSync(filePath, file.content);
+            console.log(pc.green('  ✓') + pc.dim(` ${file.path}`));
+        }
+
+        // Initialize git repository
+        if (config.initGit) {
+            console.log();
+            console.log(pc.dim('Initializing git repository...'));
+            try {
+                execSync('git init', { cwd: projectPath, stdio: 'ignore' });
+                console.log(pc.green('  ✓') + pc.dim(' Git repository initialized'));
+            } catch {
+                console.log(pc.yellow('  ⚠') + pc.dim(' Failed to initialize git repository'));
+            }
+        }
+
+        // Install dependencies
+        if (config.installDeps) {
+            console.log();
+            console.log(pc.dim(`Installing dependencies with ${config.packageManager}...`));
+
+            try {
+                const installCmd = getInstallCommand(config.packageManager);
+                execSync(installCmd, { cwd: projectPath, stdio: 'inherit' });
+                console.log(pc.green('  ✓') + pc.dim(' Dependencies installed'));
+            } catch {
+                console.log(pc.yellow('  ⚠') + pc.dim(' Failed to install dependencies'));
+                console.log(
+                    pc.dim(`    Run "${config.packageManager} install" manually to install dependencies`)
+                );
+            }
+        }
+
+        // Success message
+        console.log();
+        console.log(pc.green('✓ Project created successfully!'));
+        console.log();
+        console.log(pc.cyan('Next steps:'));
+        console.log();
+        console.log(pc.dim(`  cd ${targetDir}`));
+        if (!config.installDeps) {
+            console.log(pc.dim(`  ${config.packageManager} install`));
+        }
+        console.log(pc.dim(`  ${config.packageManager} run dev`));
+        console.log();
+
+        return true;
+    } catch (error) {
+        console.log(pc.red('Error creating project:'));
+        console.log(pc.dim(error instanceof Error ? error.message : String(error)));
+        return false;
+    }
+}
+
+/**
+ * Get the install command for the package manager
+ */
+function getInstallCommand(packageManager: 'npm' | 'yarn' | 'pnpm'): string {
+    switch (packageManager) {
+        case 'yarn':
+            return 'yarn';
+        case 'pnpm':
+            return 'pnpm install';
+        default:
+            return 'npm install';
+    }
+}

--- a/packages/create/src/help.ts
+++ b/packages/create/src/help.ts
@@ -1,0 +1,59 @@
+import pc from 'picocolors';
+import { templates } from './templates.js';
+
+// Package version (will be replaced at build time)
+const VERSION = '0.1.0';
+
+/**
+ * Print the CLI banner
+ */
+export function printBanner(): void {
+    console.log();
+    console.log(pc.cyan(pc.bold('  OrionECS Project Creator')));
+    console.log(pc.dim(`  v${VERSION}`));
+    console.log();
+}
+
+/**
+ * Print help text
+ */
+export function printHelp(): void {
+    console.log(`
+${pc.cyan(pc.bold('OrionECS Project Creator'))}
+
+${pc.bold('Usage:')}
+  ${pc.dim('$')} npm create @orion-ecs [project-name] [options]
+  ${pc.dim('$')} npx @orion-ecs/create [project-name] [options]
+
+${pc.bold('Options:')}
+  ${pc.cyan('-h, --help')}              Show this help message
+  ${pc.cyan('-v, --version')}           Show version number
+  ${pc.cyan('-y, --yes')}               Skip prompts and use defaults
+  ${pc.cyan('-t, --template')} <name>   Use a specific template
+  ${pc.cyan('-p, --package-manager')} <pm>  Use npm, yarn, or pnpm
+  ${pc.cyan('--skip-install')}          Skip dependency installation
+  ${pc.cyan('--skip-git')}              Skip git initialization
+  ${pc.cyan('--javascript, --js')}      Use JavaScript instead of TypeScript
+
+${pc.bold('Templates:')}
+${Object.values(templates)
+    .map((t) => `  ${pc.cyan(t.id.padEnd(12))} ${pc.dim(t.description)}`)
+    .join('\n')}
+
+${pc.bold('Examples:')}
+  ${pc.dim('$')} npm create @orion-ecs my-game
+  ${pc.dim('$')} npm create @orion-ecs my-game -t pixi
+  ${pc.dim('$')} npm create @orion-ecs my-game -t three --skip-install
+  ${pc.dim('$')} npm create @orion-ecs my-game -y -t canvas2d
+
+${pc.bold('Documentation:')}
+  ${pc.cyan('https://github.com/tyevco/orionecs')}
+`);
+}
+
+/**
+ * Print version number
+ */
+export function printVersion(): void {
+    console.log(`@orion-ecs/create v${VERSION}`);
+}

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @orion-ecs/create
+ *
+ * Create OrionECS projects with a single command.
+ */
+
+export { createProject } from './generator.js';
+export { runPrompts } from './prompts.js';
+export { templates, getTemplateInfo, getTemplateChoices, isValidTemplate } from './templates.js';
+export { generateTemplateFiles } from './template-files.js';
+export type {
+    ProjectConfig,
+    TemplateType,
+    TemplateInfo,
+    TemplateFile,
+    CliOptions,
+} from './types.js';

--- a/packages/create/src/prompts.ts
+++ b/packages/create/src/prompts.ts
@@ -1,0 +1,163 @@
+import prompts from 'prompts';
+import pc from 'picocolors';
+import type { ProjectConfig, CliOptions } from './types.js';
+import { getTemplateChoices, isValidTemplate } from './templates.js';
+
+/**
+ * Validate project name
+ */
+function validateProjectName(name: string): boolean | string {
+    if (!name) {
+        return 'Project name is required';
+    }
+    if (!/^[a-z0-9-_]+$/i.test(name)) {
+        return 'Project name can only contain letters, numbers, dashes, and underscores';
+    }
+    if (name.startsWith('-') || name.startsWith('_')) {
+        return 'Project name cannot start with a dash or underscore';
+    }
+    return true;
+}
+
+/**
+ * Run interactive prompts to gather project configuration
+ */
+export async function runPrompts(options: CliOptions): Promise<ProjectConfig | null> {
+    const results: Partial<ProjectConfig> = {};
+
+    // Handle cancellation
+    const onCancel = () => {
+        console.log(pc.red('\nProject creation cancelled.'));
+        process.exit(0);
+    };
+
+    try {
+        // Project name
+        if (options.projectName) {
+            const validation = validateProjectName(options.projectName);
+            if (validation !== true) {
+                console.log(pc.red(`Invalid project name: ${validation}`));
+                return null;
+            }
+            results.name = options.projectName;
+        } else if (!options.yes) {
+            const response = await prompts(
+                {
+                    type: 'text',
+                    name: 'name',
+                    message: 'Project name:',
+                    initial: 'my-orion-game',
+                    validate: validateProjectName,
+                },
+                { onCancel }
+            );
+            results.name = response.name;
+        } else {
+            results.name = 'my-orion-game';
+        }
+
+        // Template selection
+        if (options.template && isValidTemplate(options.template)) {
+            results.template = options.template;
+        } else if (!options.yes) {
+            const response = await prompts(
+                {
+                    type: 'select',
+                    name: 'template',
+                    message: 'Select a template:',
+                    choices: getTemplateChoices(),
+                    initial: 0,
+                },
+                { onCancel }
+            );
+            results.template = response.template;
+        } else {
+            results.template = 'vanilla';
+        }
+
+        // Language preference (TypeScript or JavaScript)
+        if (options.javascript !== undefined) {
+            results.language = options.javascript ? 'javascript' : 'typescript';
+        } else if (!options.yes) {
+            const response = await prompts(
+                {
+                    type: 'select',
+                    name: 'language',
+                    message: 'Select language:',
+                    choices: [
+                        { title: 'TypeScript', value: 'typescript', description: 'Recommended' },
+                        { title: 'JavaScript', value: 'javascript' },
+                    ],
+                    initial: 0,
+                },
+                { onCancel }
+            );
+            results.language = response.language;
+        } else {
+            results.language = 'typescript';
+        }
+
+        // Package manager
+        if (options.packageManager) {
+            results.packageManager = options.packageManager;
+        } else if (!options.yes) {
+            const response = await prompts(
+                {
+                    type: 'select',
+                    name: 'packageManager',
+                    message: 'Select package manager:',
+                    choices: [
+                        { title: 'npm', value: 'npm' },
+                        { title: 'yarn', value: 'yarn' },
+                        { title: 'pnpm', value: 'pnpm' },
+                    ],
+                    initial: 0,
+                },
+                { onCancel }
+            );
+            results.packageManager = response.packageManager;
+        } else {
+            results.packageManager = 'npm';
+        }
+
+        // Install dependencies
+        if (options.skipInstall !== undefined) {
+            results.installDeps = !options.skipInstall;
+        } else if (!options.yes) {
+            const response = await prompts(
+                {
+                    type: 'confirm',
+                    name: 'installDeps',
+                    message: 'Install dependencies?',
+                    initial: true,
+                },
+                { onCancel }
+            );
+            results.installDeps = response.installDeps;
+        } else {
+            results.installDeps = true;
+        }
+
+        // Initialize git
+        if (options.skipGit !== undefined) {
+            results.initGit = !options.skipGit;
+        } else if (!options.yes) {
+            const response = await prompts(
+                {
+                    type: 'confirm',
+                    name: 'initGit',
+                    message: 'Initialize git repository?',
+                    initial: true,
+                },
+                { onCancel }
+            );
+            results.initGit = response.initGit;
+        } else {
+            results.initGit = true;
+        }
+
+        return results as ProjectConfig;
+    } catch {
+        return null;
+    }
+}

--- a/packages/create/src/template-files.ts
+++ b/packages/create/src/template-files.ts
@@ -1,0 +1,1367 @@
+import type { ProjectConfig, TemplateFile } from './types.js';
+import { getTemplateInfo } from './templates.js';
+
+/**
+ * Generate all template files for the project
+ */
+export function generateTemplateFiles(config: ProjectConfig): TemplateFile[] {
+    const files: TemplateFile[] = [];
+    const isTS = config.language === 'typescript';
+    const ext = isTS ? 'ts' : 'js';
+
+    // Common files
+    files.push(generatePackageJson(config));
+    files.push(generateGitignore());
+    files.push(generateReadme(config));
+
+    if (isTS) {
+        files.push(generateTsConfig(config));
+    }
+
+    // Template-specific files
+    switch (config.template) {
+        case 'vanilla':
+            files.push(...generateVanillaFiles(config, ext));
+            break;
+        case 'canvas2d':
+            files.push(...generateCanvas2dFiles(config, ext));
+            break;
+        case 'pixi':
+            files.push(...generatePixiFiles(config, ext));
+            break;
+        case 'three':
+            files.push(...generateThreeFiles(config, ext));
+            break;
+        case 'multiplayer':
+            files.push(...generateMultiplayerFiles(config, ext));
+            break;
+        case 'vite':
+            files.push(...generateViteFiles(config, ext));
+            break;
+        case 'webpack':
+            files.push(...generateWebpackFiles(config, ext));
+            break;
+    }
+
+    return files;
+}
+
+/**
+ * Generate package.json
+ */
+function generatePackageJson(config: ProjectConfig): TemplateFile {
+    const templateInfo = getTemplateInfo(config.template);
+    const isTS = config.language === 'typescript';
+
+    const scripts: Record<string, string> = {};
+
+    // Add scripts based on template
+    switch (config.template) {
+        case 'vanilla':
+            scripts.build = isTS ? 'tsc' : 'echo "No build step for JavaScript"';
+            scripts.dev = isTS ? 'tsx watch src/index.ts' : 'node src/index.js';
+            scripts.start = isTS ? 'tsx src/index.ts' : 'node src/index.js';
+            break;
+        case 'canvas2d':
+        case 'pixi':
+        case 'three':
+        case 'vite':
+            scripts.dev = 'vite';
+            scripts.build = isTS ? 'tsc && vite build' : 'vite build';
+            scripts.preview = 'vite preview';
+            break;
+        case 'multiplayer':
+            scripts.dev = 'tsx watch src/server.ts';
+            scripts['dev:client'] = 'vite';
+            scripts.build = isTS ? 'tsc && vite build' : 'vite build';
+            scripts.start = isTS ? 'tsx src/server.ts' : 'node src/server.js';
+            break;
+        case 'webpack':
+            scripts.dev = 'webpack serve --mode development';
+            scripts.build = 'webpack --mode production';
+            break;
+    }
+
+    const packageJson = {
+        name: config.name,
+        version: '0.1.0',
+        private: true,
+        description: `${config.name} - OrionECS game`,
+        type: 'module',
+        main: isTS ? 'dist/index.js' : 'src/index.js',
+        scripts,
+        keywords: ['orion-ecs', 'game'],
+        dependencies: templateInfo?.dependencies ?? {},
+        devDependencies: {
+            ...templateInfo?.devDependencies,
+            ...(config.template === 'vanilla' && isTS ? { tsx: '^4.0.0' } : {}),
+        },
+    };
+
+    return {
+        path: 'package.json',
+        content: JSON.stringify(packageJson, null, 2) + '\n',
+    };
+}
+
+/**
+ * Generate .gitignore
+ */
+function generateGitignore(): TemplateFile {
+    return {
+        path: '.gitignore',
+        content: `# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Testing
+coverage/
+
+# Environment
+.env
+.env.local
+.env.*.local
+`,
+    };
+}
+
+/**
+ * Generate README.md
+ */
+function generateReadme(config: ProjectConfig): TemplateFile {
+    const templateInfo = getTemplateInfo(config.template);
+
+    return {
+        path: 'README.md',
+        content: `# ${config.name}
+
+${templateInfo?.description ?? 'An OrionECS game project.'}
+
+## Getting Started
+
+\`\`\`bash
+# Install dependencies
+${config.packageManager} install
+
+# Start development server
+${config.packageManager} run dev
+
+# Build for production
+${config.packageManager} run build
+\`\`\`
+
+## Project Structure
+
+\`\`\`
+${config.name}/
+├── src/
+│   ├── components/     # ECS components
+│   ├── systems/        # ECS systems
+│   └── index.${config.language === 'typescript' ? 'ts' : 'js'}
+├── package.json
+└── README.md
+\`\`\`
+
+## Learn More
+
+- [OrionECS Documentation](https://github.com/tyevco/orionecs)
+- [OrionECS API Reference](https://github.com/tyevco/orionecs/blob/main/docs/API.md)
+`,
+    };
+}
+
+/**
+ * Generate tsconfig.json
+ */
+function generateTsConfig(config: ProjectConfig): TemplateFile {
+    const isBrowser = ['canvas2d', 'pixi', 'three', 'vite', 'webpack', 'multiplayer'].includes(
+        config.template
+    );
+
+    const tsconfig = {
+        compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            lib: isBrowser ? ['ES2022', 'DOM', 'DOM.Iterable'] : ['ES2022'],
+            strict: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+            declarationMap: true,
+            sourceMap: true,
+            outDir: './dist',
+            rootDir: './src',
+            noUnusedLocals: true,
+            noUnusedParameters: true,
+            noImplicitReturns: true,
+            resolveJsonModule: true,
+        },
+        include: ['src/**/*'],
+        exclude: ['node_modules', 'dist'],
+    };
+
+    return {
+        path: 'tsconfig.json',
+        content: JSON.stringify(tsconfig, null, 2) + '\n',
+    };
+}
+
+/**
+ * Generate vanilla template files
+ */
+function generateVanillaFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    const isTS = ext === 'ts';
+
+    return [
+        {
+            path: `src/index.${ext}`,
+            content: `/**
+ * ${config.name} - OrionECS Game
+ */
+
+import { EngineBuilder } from '@orion-ecs/core';
+import { Position, Velocity } from './components/transform.${ext.replace('.ts', '')}${isTS ? '.js' : ''}';
+import { MovementSystem } from './systems/movement.${ext.replace('.ts', '')}${isTS ? '.js' : ''}';
+
+// Create the ECS engine
+const engine = new EngineBuilder()
+    .withDebugMode(true)
+    .withFixedUpdateFPS(60)
+    .build();
+
+// Register systems
+engine.registerSystem(new MovementSystem(engine));
+
+// Create a player entity
+const player = engine.createEntity('Player');
+player
+    .addComponent(Position, 0, 0)
+    .addComponent(Velocity, 1, 1)
+    .addTag('player');
+
+console.log('Game started!');
+console.log('Player entity created:', player.name);
+
+// Run the game loop
+engine.run();
+
+// Log entity state periodically
+setInterval(() => {
+    const pos = player.getComponent(Position);
+    console.log(\`Player position: (\${pos.x.toFixed(2)}, \${pos.y.toFixed(2)})\`);
+}, 1000);
+`,
+        },
+        {
+            path: `src/components/transform.${ext}`,
+            content: `/**
+ * Transform components
+ */
+
+export class Position {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class Velocity {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+`,
+        },
+        {
+            path: `src/systems/movement.${ext}`,
+            content: `/**
+ * Movement System
+ */
+
+import { Position, Velocity } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class MovementSystem {
+    constructor(private engine${isTS ? ': Engine' : ''}) {
+        this.engine.createSystem(
+            'MovementSystem',
+            { all: [Position, Velocity] },
+            {
+                priority: 100,
+                act: this.act.bind(this),
+            }
+        );
+    }
+
+    act(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position' : ''}, velocity${isTS ? ': Velocity' : ''})${isTS ? ': void' : ''} {
+        const deltaTime = 1 / 60; // Fixed timestep
+        position.x += velocity.x * deltaTime;
+        position.y += velocity.y * deltaTime;
+    }
+}
+`,
+        },
+    ];
+}
+
+/**
+ * Generate Canvas2D template files
+ */
+function generateCanvas2dFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    const isTS = ext === 'ts';
+
+    return [
+        {
+            path: 'index.html',
+            content: `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${config.name}</title>
+    <style>
+        body {
+            margin: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            background: #1a1a2e;
+        }
+        canvas {
+            border: 2px solid #16213e;
+            background: #0f0f23;
+        }
+    </style>
+</head>
+<body>
+    <canvas id="game" width="800" height="600"></canvas>
+    <script type="module" src="/src/index.${ext}"></script>
+</body>
+</html>
+`,
+        },
+        {
+            path: `src/index.${ext}`,
+            content: `/**
+ * ${config.name} - Canvas2D Game
+ */
+
+import { EngineBuilder } from '@orion-ecs/core';
+import { Position, Velocity, Sprite } from './components/transform.${isTS ? 'js' : ext}';
+import { MovementSystem } from './systems/movement.${isTS ? 'js' : ext}';
+import { RenderSystem } from './systems/render.${isTS ? 'js' : ext}';
+
+// Get canvas and context
+const canvas = document.getElementById('game')${isTS ? ' as HTMLCanvasElement' : ''};
+const ctx = canvas.getContext('2d')${isTS ? '!' : ''};
+
+// Create the ECS engine
+const engine = new EngineBuilder()
+    .withDebugMode(true)
+    .withFixedUpdateFPS(60)
+    .build();
+
+// Register systems
+new MovementSystem(engine);
+new RenderSystem(engine, ctx);
+
+// Create player entity
+const player = engine.createEntity('Player');
+player
+    .addComponent(Position, 400, 300)
+    .addComponent(Velocity, 100, 50)
+    .addComponent(Sprite, 32, 32, '#00ff88')
+    .addTag('player');
+
+// Create some bouncing entities
+for (let i = 0; i < 5; i++) {
+    const entity = engine.createEntity(\`Ball\${i}\`);
+    entity
+        .addComponent(Position, Math.random() * 700 + 50, Math.random() * 500 + 50)
+        .addComponent(Velocity, (Math.random() - 0.5) * 200, (Math.random() - 0.5) * 200)
+        .addComponent(Sprite, 20, 20, \`hsl(\${Math.random() * 360}, 70%, 60%)\`)
+        .addTag('ball');
+}
+
+console.log('Game started!');
+engine.run();
+`,
+        },
+        {
+            path: `src/components/transform.${ext}`,
+            content: `/**
+ * Transform and visual components
+ */
+
+export class Position {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class Velocity {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class Sprite {
+    constructor(
+        public width${isTS ? ': number' : ''} = 32,
+        public height${isTS ? ': number' : ''} = 32,
+        public color${isTS ? ': string' : ''} = '#ffffff'
+    ) {}
+}
+`,
+        },
+        {
+            path: `src/systems/movement.${ext}`,
+            content: `/**
+ * Movement System with boundary bouncing
+ */
+
+import { Position, Velocity } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class MovementSystem {
+    constructor(private engine${isTS ? ': Engine' : ''}) {
+        this.engine.createSystem(
+            'MovementSystem',
+            { all: [Position, Velocity] },
+            {
+                priority: 100,
+                act: this.act.bind(this),
+            }
+        );
+    }
+
+    act(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position' : ''}, velocity${isTS ? ': Velocity' : ''})${isTS ? ': void' : ''} {
+        const deltaTime = 1 / 60;
+        position.x += velocity.x * deltaTime;
+        position.y += velocity.y * deltaTime;
+
+        // Bounce off walls
+        if (position.x < 0 || position.x > 800) {
+            velocity.x *= -1;
+            position.x = Math.max(0, Math.min(800, position.x));
+        }
+        if (position.y < 0 || position.y > 600) {
+            velocity.y *= -1;
+            position.y = Math.max(0, Math.min(600, position.y));
+        }
+    }
+}
+`,
+        },
+        {
+            path: `src/systems/render.${ext}`,
+            content: `/**
+ * Canvas2D Render System
+ */
+
+import { Position, Sprite } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class RenderSystem {
+    constructor(
+        private engine${isTS ? ': Engine' : ''},
+        private ctx${isTS ? ': CanvasRenderingContext2D' : ''}
+    ) {
+        this.engine.createSystem(
+            'RenderSystem',
+            { all: [Position, Sprite] },
+            {
+                priority: 10, // Run after movement
+                beforeAll: this.clear.bind(this),
+                act: this.render.bind(this),
+            }
+        );
+    }
+
+    clear()${isTS ? ': void' : ''} {
+        this.ctx.fillStyle = '#0f0f23';
+        this.ctx.fillRect(0, 0, 800, 600);
+    }
+
+    render(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position' : ''}, sprite${isTS ? ': Sprite' : ''})${isTS ? ': void' : ''} {
+        this.ctx.fillStyle = sprite.color;
+        this.ctx.fillRect(
+            position.x - sprite.width / 2,
+            position.y - sprite.height / 2,
+            sprite.width,
+            sprite.height
+        );
+    }
+}
+`,
+        },
+        generateViteConfig(config),
+    ];
+}
+
+/**
+ * Generate Pixi.js template files
+ */
+function generatePixiFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    const isTS = ext === 'ts';
+
+    return [
+        {
+            path: 'index.html',
+            content: `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${config.name}</title>
+    <style>
+        body {
+            margin: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            background: #1a1a2e;
+        }
+        canvas {
+            border: 2px solid #16213e;
+        }
+    </style>
+</head>
+<body>
+    <script type="module" src="/src/index.${ext}"></script>
+</body>
+</html>
+`,
+        },
+        {
+            path: `src/index.${ext}`,
+            content: `/**
+ * ${config.name} - Pixi.js Game
+ */
+
+import { Application, Graphics } from 'pixi.js';
+import { EngineBuilder } from '@orion-ecs/core';
+import { Position, Velocity, PixiRenderable } from './components/transform.${isTS ? 'js' : ext}';
+import { MovementSystem } from './systems/movement.${isTS ? 'js' : ext}';
+import { PixiRenderSystem } from './systems/render.${isTS ? 'js' : ext}';
+
+async function main() {
+    // Create Pixi Application
+    const app = new Application();
+    await app.init({
+        width: 800,
+        height: 600,
+        backgroundColor: 0x0f0f23,
+    });
+    document.body.appendChild(app.canvas);
+
+    // Create the ECS engine
+    const engine = new EngineBuilder()
+        .withDebugMode(true)
+        .withFixedUpdateFPS(60)
+        .build();
+
+    // Register systems
+    new MovementSystem(engine);
+    new PixiRenderSystem(engine, app);
+
+    // Create player entity
+    const player = engine.createEntity('Player');
+    const playerGraphics = new Graphics()
+        .rect(-16, -16, 32, 32)
+        .fill(0x00ff88);
+    app.stage.addChild(playerGraphics);
+
+    player
+        .addComponent(Position, 400, 300)
+        .addComponent(Velocity, 100, 50)
+        .addComponent(PixiRenderable, playerGraphics)
+        .addTag('player');
+
+    // Create some bouncing entities
+    for (let i = 0; i < 5; i++) {
+        const entity = engine.createEntity(\`Ball\${i}\`);
+        const graphics = new Graphics()
+            .circle(0, 0, 10)
+            .fill(Math.random() * 0xffffff);
+        app.stage.addChild(graphics);
+
+        entity
+            .addComponent(Position, Math.random() * 700 + 50, Math.random() * 500 + 50)
+            .addComponent(Velocity, (Math.random() - 0.5) * 200, (Math.random() - 0.5) * 200)
+            .addComponent(PixiRenderable, graphics)
+            .addTag('ball');
+    }
+
+    console.log('Game started!');
+    engine.run();
+}
+
+main().catch(console.error);
+`,
+        },
+        {
+            path: `src/components/transform.${ext}`,
+            content: `/**
+ * Transform and visual components
+ */
+${isTS ? "import type { Container } from 'pixi.js';" : ''}
+
+export class Position {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class Velocity {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class PixiRenderable {
+    constructor(public displayObject${isTS ? ': Container' : ''}) {}
+}
+`,
+        },
+        {
+            path: `src/systems/movement.${ext}`,
+            content: `/**
+ * Movement System with boundary bouncing
+ */
+
+import { Position, Velocity } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class MovementSystem {
+    constructor(private engine${isTS ? ': Engine' : ''}) {
+        this.engine.createSystem(
+            'MovementSystem',
+            { all: [Position, Velocity] },
+            {
+                priority: 100,
+                act: this.act.bind(this),
+            }
+        );
+    }
+
+    act(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position' : ''}, velocity${isTS ? ': Velocity' : ''})${isTS ? ': void' : ''} {
+        const deltaTime = 1 / 60;
+        position.x += velocity.x * deltaTime;
+        position.y += velocity.y * deltaTime;
+
+        // Bounce off walls
+        if (position.x < 0 || position.x > 800) {
+            velocity.x *= -1;
+            position.x = Math.max(0, Math.min(800, position.x));
+        }
+        if (position.y < 0 || position.y > 600) {
+            velocity.y *= -1;
+            position.y = Math.max(0, Math.min(600, position.y));
+        }
+    }
+}
+`,
+        },
+        {
+            path: `src/systems/render.${ext}`,
+            content: `/**
+ * Pixi.js Render System
+ */
+
+import { Position, PixiRenderable } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Application } from 'pixi.js';\nimport type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class PixiRenderSystem {
+    constructor(
+        private engine${isTS ? ': Engine' : ''},
+        private app${isTS ? ': Application' : ''}
+    ) {
+        this.engine.createSystem(
+            'PixiRenderSystem',
+            { all: [Position, PixiRenderable] },
+            {
+                priority: 10,
+                act: this.render.bind(this),
+            }
+        );
+    }
+
+    render(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position' : ''}, renderable${isTS ? ': PixiRenderable' : ''})${isTS ? ': void' : ''} {
+        renderable.displayObject.x = position.x;
+        renderable.displayObject.y = position.y;
+    }
+}
+`,
+        },
+        generateViteConfig(config),
+    ];
+}
+
+/**
+ * Generate Three.js template files
+ */
+function generateThreeFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    const isTS = ext === 'ts';
+
+    return [
+        {
+            path: 'index.html',
+            content: `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${config.name}</title>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        canvas { display: block; }
+    </style>
+</head>
+<body>
+    <script type="module" src="/src/index.${ext}"></script>
+</body>
+</html>
+`,
+        },
+        {
+            path: `src/index.${ext}`,
+            content: `/**
+ * ${config.name} - Three.js 3D Game
+ */
+
+import * as THREE from 'three';
+import { EngineBuilder } from '@orion-ecs/core';
+import { Position3D, Velocity3D, ThreeRenderable } from './components/transform.${isTS ? 'js' : ext}';
+import { MovementSystem } from './systems/movement.${isTS ? 'js' : ext}';
+import { ThreeRenderSystem } from './systems/render.${isTS ? 'js' : ext}';
+
+// Create Three.js scene
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x1a1a2e);
+
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.z = 10;
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+// Add lighting
+const ambientLight = new THREE.AmbientLight(0x404040);
+scene.add(ambientLight);
+
+const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+directionalLight.position.set(5, 5, 5);
+scene.add(directionalLight);
+
+// Create the ECS engine
+const engine = new EngineBuilder()
+    .withDebugMode(true)
+    .withFixedUpdateFPS(60)
+    .build();
+
+// Register systems
+new MovementSystem(engine);
+new ThreeRenderSystem(engine);
+
+// Create player cube
+const playerGeometry = new THREE.BoxGeometry(1, 1, 1);
+const playerMaterial = new THREE.MeshStandardMaterial({ color: 0x00ff88 });
+const playerMesh = new THREE.Mesh(playerGeometry, playerMaterial);
+scene.add(playerMesh);
+
+const player = engine.createEntity('Player');
+player
+    .addComponent(Position3D, 0, 0, 0)
+    .addComponent(Velocity3D, 0.5, 0.3, 0)
+    .addComponent(ThreeRenderable, playerMesh)
+    .addTag('player');
+
+// Create some floating cubes
+for (let i = 0; i < 10; i++) {
+    const geometry = new THREE.BoxGeometry(0.5, 0.5, 0.5);
+    const material = new THREE.MeshStandardMaterial({ color: Math.random() * 0xffffff });
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const entity = engine.createEntity(\`Cube\${i}\`);
+    entity
+        .addComponent(Position3D, (Math.random() - 0.5) * 10, (Math.random() - 0.5) * 6, (Math.random() - 0.5) * 5)
+        .addComponent(Velocity3D, (Math.random() - 0.5), (Math.random() - 0.5), 0)
+        .addComponent(ThreeRenderable, mesh)
+        .addTag('cube');
+}
+
+console.log('Game started!');
+engine.run();
+
+// Three.js render loop
+function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+}
+animate();
+
+// Handle window resize
+window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+});
+`,
+        },
+        {
+            path: `src/components/transform.${ext}`,
+            content: `/**
+ * 3D Transform components
+ */
+${isTS ? "import type { Object3D } from 'three';" : ''}
+
+export class Position3D {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0,
+        public z${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class Velocity3D {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0,
+        public z${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class ThreeRenderable {
+    constructor(public object${isTS ? ': Object3D' : ''}) {}
+}
+`,
+        },
+        {
+            path: `src/systems/movement.${ext}`,
+            content: `/**
+ * 3D Movement System with boundary bouncing
+ */
+
+import { Position3D, Velocity3D } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class MovementSystem {
+    constructor(private engine${isTS ? ': Engine' : ''}) {
+        this.engine.createSystem(
+            'MovementSystem',
+            { all: [Position3D, Velocity3D] },
+            {
+                priority: 100,
+                act: this.act.bind(this),
+            }
+        );
+    }
+
+    act(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position3D' : ''}, velocity${isTS ? ': Velocity3D' : ''})${isTS ? ': void' : ''} {
+        const deltaTime = 1 / 60;
+        position.x += velocity.x * deltaTime;
+        position.y += velocity.y * deltaTime;
+        position.z += velocity.z * deltaTime;
+
+        // Bounce off boundaries
+        const bound = 5;
+        if (Math.abs(position.x) > bound) {
+            velocity.x *= -1;
+            position.x = Math.sign(position.x) * bound;
+        }
+        if (Math.abs(position.y) > bound) {
+            velocity.y *= -1;
+            position.y = Math.sign(position.y) * bound;
+        }
+    }
+}
+`,
+        },
+        {
+            path: `src/systems/render.${ext}`,
+            content: `/**
+ * Three.js Render System
+ */
+
+import { Position3D, ThreeRenderable } from '../components/transform.${isTS ? 'js' : ext}';
+${isTS ? "import type { Engine, Entity } from '@orion-ecs/core';" : ''}
+
+export class ThreeRenderSystem {
+    constructor(private engine${isTS ? ': Engine' : ''}) {
+        this.engine.createSystem(
+            'ThreeRenderSystem',
+            { all: [Position3D, ThreeRenderable] },
+            {
+                priority: 10,
+                act: this.render.bind(this),
+            }
+        );
+    }
+
+    render(_entity${isTS ? ': Entity' : ''}, position${isTS ? ': Position3D' : ''}, renderable${isTS ? ': ThreeRenderable' : ''})${isTS ? ': void' : ''} {
+        renderable.object.position.set(position.x, position.y, position.z);
+        renderable.object.rotation.x += 0.01;
+        renderable.object.rotation.y += 0.01;
+    }
+}
+`,
+        },
+        generateViteConfig(config),
+    ];
+}
+
+/**
+ * Generate Multiplayer template files
+ */
+function generateMultiplayerFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    const isTS = ext === 'ts';
+
+    return [
+        {
+            path: `src/server.${ext}`,
+            content: `/**
+ * ${config.name} - Multiplayer Server
+ */
+
+import { WebSocketServer } from 'ws';
+import { EngineBuilder } from '@orion-ecs/core';
+import { Position, Velocity, NetworkId } from './shared/components.${isTS ? 'js' : ext}';
+
+const PORT = process.env.PORT || 8080;
+
+// Create the ECS engine for server
+const engine = new EngineBuilder()
+    .withDebugMode(true)
+    .withFixedUpdateFPS(60)
+    .build();
+
+// WebSocket server
+const wss = new WebSocketServer({ port: Number(PORT) });
+const clients${isTS ? ': Map<string, any>' : ''} = new Map();
+let nextPlayerId = 1;
+
+console.log(\`Server running on ws://localhost:\${PORT}\`);
+
+wss.on('connection', (ws) => {
+    const playerId = \`player_\${nextPlayerId++}\`;
+    clients.set(playerId, ws);
+    console.log(\`Player connected: \${playerId}\`);
+
+    // Create entity for this player
+    const entity = engine.createEntity(playerId);
+    entity
+        .addComponent(Position, Math.random() * 700 + 50, Math.random() * 500 + 50)
+        .addComponent(Velocity, 0, 0)
+        .addComponent(NetworkId, playerId)
+        .addTag('player');
+
+    // Send initial state
+    ws.send(JSON.stringify({
+        type: 'init',
+        playerId,
+        state: getGameState(),
+    }));
+
+    // Broadcast new player to others
+    broadcast({
+        type: 'player_joined',
+        playerId,
+        position: { x: entity.getComponent(Position).x, y: entity.getComponent(Position).y },
+    }, playerId);
+
+    ws.on('message', (data) => {
+        try {
+            const message = JSON.parse(data.toString());
+            handleMessage(playerId, message);
+        } catch (e) {
+            console.error('Invalid message:', e);
+        }
+    });
+
+    ws.on('close', () => {
+        console.log(\`Player disconnected: \${playerId}\`);
+        const entity = engine.getEntityByName(playerId);
+        if (entity) {
+            engine.destroyEntity(entity);
+        }
+        clients.delete(playerId);
+        broadcast({ type: 'player_left', playerId });
+    });
+});
+
+function handleMessage(playerId${isTS ? ': string' : ''}, message${isTS ? ': any' : ''}) {
+    if (message.type === 'input') {
+        const entity = engine.getEntityByName(playerId);
+        if (entity) {
+            const velocity = entity.getComponent(Velocity);
+            velocity.x = message.x * 200;
+            velocity.y = message.y * 200;
+        }
+    }
+}
+
+function getGameState()${isTS ? ': any[]' : ''} {
+    const state${isTS ? ': any[]' : ''} = [];
+    const query = engine.createQuery({ all: [Position, NetworkId] });
+    for (const entity of query.getEntities()) {
+        const pos = entity.getComponent(Position);
+        const netId = entity.getComponent(NetworkId);
+        state.push({
+            id: netId.id,
+            x: pos.x,
+            y: pos.y,
+        });
+    }
+    return state;
+}
+
+function broadcast(message${isTS ? ': any' : ''}, excludeId${isTS ? '?: string' : ''} = undefined) {
+    const data = JSON.stringify(message);
+    for (const [id, ws] of clients) {
+        if (id !== excludeId) {
+            ws.send(data);
+        }
+    }
+}
+
+// Movement system
+engine.createSystem(
+    'MovementSystem',
+    { all: [Position, Velocity] },
+    {
+        priority: 100,
+        act: (_entity, position, velocity) => {
+            const dt = 1 / 60;
+            position.x += velocity.x * dt;
+            position.y += velocity.y * dt;
+            position.x = Math.max(0, Math.min(800, position.x));
+            position.y = Math.max(0, Math.min(600, position.y));
+        },
+    }
+);
+
+// Broadcast state periodically
+setInterval(() => {
+    broadcast({ type: 'state', state: getGameState() });
+}, 50);
+
+engine.run();
+`,
+        },
+        {
+            path: `src/shared/components.${ext}`,
+            content: `/**
+ * Shared components for client and server
+ */
+
+export class Position {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class Velocity {
+    constructor(
+        public x${isTS ? ': number' : ''} = 0,
+        public y${isTS ? ': number' : ''} = 0
+    ) {}
+}
+
+export class NetworkId {
+    constructor(public id${isTS ? ': string' : ''} = '') {}
+}
+`,
+        },
+        {
+            path: 'index.html',
+            content: `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${config.name}</title>
+    <style>
+        body {
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 20px;
+            background: #1a1a2e;
+            color: white;
+            font-family: sans-serif;
+        }
+        canvas {
+            border: 2px solid #16213e;
+            background: #0f0f23;
+        }
+        #status {
+            margin-bottom: 10px;
+            color: #888;
+        }
+    </style>
+</head>
+<body>
+    <div id="status">Connecting...</div>
+    <canvas id="game" width="800" height="600"></canvas>
+    <script type="module" src="/src/client.${ext}"></script>
+</body>
+</html>
+`,
+        },
+        {
+            path: `src/client.${ext}`,
+            content: `/**
+ * ${config.name} - Multiplayer Client
+ */
+
+const canvas = document.getElementById('game')${isTS ? ' as HTMLCanvasElement' : ''};
+const ctx = canvas.getContext('2d')${isTS ? '!' : ''};
+const status = document.getElementById('status')${isTS ? '!' : ''};
+
+let playerId${isTS ? ': string | null' : ''} = null;
+let gameState${isTS ? ': any[]' : ''} = [];
+const input = { x: 0, y: 0 };
+
+// Connect to server
+const ws = new WebSocket(\`ws://\${window.location.hostname}:8080\`);
+
+ws.onopen = () => {
+    status.textContent = 'Connected!';
+    status.style.color = '#00ff88';
+};
+
+ws.onmessage = (event) => {
+    const message = JSON.parse(event.data);
+
+    switch (message.type) {
+        case 'init':
+            playerId = message.playerId;
+            gameState = message.state;
+            break;
+        case 'state':
+            gameState = message.state;
+            break;
+        case 'player_joined':
+            console.log(\`Player joined: \${message.playerId}\`);
+            break;
+        case 'player_left':
+            console.log(\`Player left: \${message.playerId}\`);
+            break;
+    }
+};
+
+ws.onclose = () => {
+    status.textContent = 'Disconnected';
+    status.style.color = '#ff4444';
+};
+
+// Handle input
+window.addEventListener('keydown', (e) => {
+    switch (e.key) {
+        case 'ArrowUp':
+        case 'w':
+            input.y = -1;
+            break;
+        case 'ArrowDown':
+        case 's':
+            input.y = 1;
+            break;
+        case 'ArrowLeft':
+        case 'a':
+            input.x = -1;
+            break;
+        case 'ArrowRight':
+        case 'd':
+            input.x = 1;
+            break;
+    }
+    sendInput();
+});
+
+window.addEventListener('keyup', (e) => {
+    switch (e.key) {
+        case 'ArrowUp':
+        case 'w':
+        case 'ArrowDown':
+        case 's':
+            input.y = 0;
+            break;
+        case 'ArrowLeft':
+        case 'a':
+        case 'ArrowRight':
+        case 'd':
+            input.x = 0;
+            break;
+    }
+    sendInput();
+});
+
+function sendInput() {
+    if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'input', ...input }));
+    }
+}
+
+// Render loop
+function render() {
+    ctx.fillStyle = '#0f0f23';
+    ctx.fillRect(0, 0, 800, 600);
+
+    for (const player of gameState) {
+        const isMe = player.id === playerId;
+        ctx.fillStyle = isMe ? '#00ff88' : '#ff6b6b';
+        ctx.fillRect(player.x - 16, player.y - 16, 32, 32);
+
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '12px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(player.id, player.x, player.y - 24);
+    }
+
+    requestAnimationFrame(render);
+}
+
+render();
+`,
+        },
+        generateViteConfig(config),
+    ];
+}
+
+/**
+ * Generate Vite template files
+ */
+function generateViteFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    return [...generateCanvas2dFiles(config, ext)];
+}
+
+/**
+ * Generate Webpack template files
+ */
+function generateWebpackFiles(config: ProjectConfig, ext: string): TemplateFile[] {
+    const isTS = ext === 'ts';
+    const baseFiles = generateCanvas2dFiles(config, ext);
+
+    // Replace vite.config with webpack.config
+    const filesWithoutVite = baseFiles.filter((f) => !f.path.includes('vite.config'));
+
+    return [
+        ...filesWithoutVite,
+        {
+            path: `webpack.config.${ext}`,
+            content: isTS
+                ? `import path from 'path';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { Configuration } from 'webpack';
+
+const config: Configuration = {
+    entry: './src/index.ts',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+        clean: true,
+    },
+    module: {
+        rules: [
+            {
+                test: /\\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+            },
+        ],
+    },
+    resolve: {
+        extensions: ['.tsx', '.ts', '.js'],
+    },
+    plugins: [
+        new HtmlWebpackPlugin({
+            template: './index.html',
+        }),
+    ],
+    devServer: {
+        static: './dist',
+        hot: true,
+    },
+};
+
+export default config;
+`
+                : `const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+    entry: './src/index.js',
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist'),
+        clean: true,
+    },
+    plugins: [
+        new HtmlWebpackPlugin({
+            template: './index.html',
+        }),
+    ],
+    devServer: {
+        static: './dist',
+        hot: true,
+    },
+};
+`,
+        },
+    ];
+}
+
+/**
+ * Generate vite.config.ts
+ */
+function generateViteConfig(config: ProjectConfig): TemplateFile {
+    const isTS = config.language === 'typescript';
+
+    return {
+        path: `vite.config.${isTS ? 'ts' : 'js'}`,
+        content: `import { defineConfig } from 'vite';
+
+export default defineConfig({
+    server: {
+        port: 3000,
+        open: true,
+    },
+    build: {
+        outDir: 'dist',
+        sourcemap: true,
+    },
+});
+`,
+    };
+}

--- a/packages/create/src/templates.ts
+++ b/packages/create/src/templates.ts
@@ -1,0 +1,136 @@
+import type { TemplateInfo, TemplateType } from './types.js';
+
+/**
+ * Available project templates
+ */
+export const templates: Record<TemplateType, TemplateInfo> = {
+    vanilla: {
+        id: 'vanilla',
+        name: 'Vanilla',
+        description: 'Minimal setup with just OrionECS core',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            tsup: '^8.5.1',
+            '@types/node': '^22.14.0',
+        },
+        tags: ['minimal', 'basic', 'console'],
+    },
+    canvas2d: {
+        id: 'canvas2d',
+        name: 'Canvas 2D',
+        description: 'Browser-based 2D game with Canvas API',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+            '@orion-ecs/canvas2d-renderer': '^0.4.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            vite: '^6.0.7',
+        },
+        tags: ['browser', '2d', 'canvas'],
+    },
+    pixi: {
+        id: 'pixi',
+        name: 'Pixi.js',
+        description: '2D game with Pixi.js rendering engine',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+            'pixi.js': '^8.0.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            vite: '^6.0.7',
+        },
+        tags: ['browser', '2d', 'pixi', 'webgl'],
+    },
+    three: {
+        id: 'three',
+        name: 'Three.js',
+        description: '3D game with Three.js rendering engine',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+            three: '^0.170.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            '@types/three': '^0.170.0',
+            vite: '^6.0.7',
+        },
+        tags: ['browser', '3d', 'three', 'webgl'],
+    },
+    multiplayer: {
+        id: 'multiplayer',
+        name: 'Multiplayer',
+        description: 'Networked multiplayer game with server and client',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+            '@orion-ecs/network': '^0.4.0',
+            ws: '^8.18.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            '@types/ws': '^8.5.10',
+            vite: '^6.0.7',
+            tsx: '^4.0.0',
+        },
+        tags: ['network', 'multiplayer', 'server', 'client'],
+    },
+    vite: {
+        id: 'vite',
+        name: 'Vite',
+        description: 'Modern browser setup with Vite bundler',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            vite: '^6.0.7',
+        },
+        tags: ['browser', 'vite', 'modern'],
+    },
+    webpack: {
+        id: 'webpack',
+        name: 'Webpack',
+        description: 'Browser setup with Webpack bundler',
+        dependencies: {
+            '@orion-ecs/core': '^0.4.0',
+        },
+        devDependencies: {
+            typescript: '^5.9.3',
+            webpack: '^5.97.0',
+            'webpack-cli': '^6.0.0',
+            'webpack-dev-server': '^5.2.0',
+            'ts-loader': '^9.5.0',
+            'html-webpack-plugin': '^5.6.0',
+        },
+        tags: ['browser', 'webpack'],
+    },
+};
+
+/**
+ * Get all template options for prompts
+ */
+export function getTemplateChoices(): Array<{ title: string; value: TemplateType; description: string }> {
+    return Object.values(templates).map((template) => ({
+        title: template.name,
+        value: template.id,
+        description: template.description,
+    }));
+}
+
+/**
+ * Get template info by ID
+ */
+export function getTemplateInfo(id: TemplateType): TemplateInfo | undefined {
+    return templates[id];
+}
+
+/**
+ * Check if template ID is valid
+ */
+export function isValidTemplate(id: string): id is TemplateType {
+    return id in templates;
+}

--- a/packages/create/src/types.ts
+++ b/packages/create/src/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Project configuration options
+ */
+export interface ProjectConfig {
+    /** Project name (also used as directory name) */
+    name: string;
+    /** Template to use */
+    template: TemplateType;
+    /** Language preference */
+    language: 'typescript' | 'javascript';
+    /** Package manager to use */
+    packageManager: 'npm' | 'yarn' | 'pnpm';
+    /** Whether to install dependencies */
+    installDeps: boolean;
+    /** Whether to initialize git */
+    initGit: boolean;
+    /** Target directory (defaults to project name) */
+    targetDir?: string;
+}
+
+/**
+ * Available project templates
+ */
+export type TemplateType =
+    | 'vanilla'
+    | 'canvas2d'
+    | 'pixi'
+    | 'three'
+    | 'multiplayer'
+    | 'vite'
+    | 'webpack';
+
+/**
+ * Template metadata
+ */
+export interface TemplateInfo {
+    /** Template identifier */
+    id: TemplateType;
+    /** Display name */
+    name: string;
+    /** Template description */
+    description: string;
+    /** Additional dependencies */
+    dependencies: Record<string, string>;
+    /** Dev dependencies */
+    devDependencies: Record<string, string>;
+    /** Tags for filtering */
+    tags: string[];
+}
+
+/**
+ * File entry in a template
+ */
+export interface TemplateFile {
+    /** Relative path to file */
+    path: string;
+    /** File content (can be template string with placeholders) */
+    content: string;
+}
+
+/**
+ * CLI options from command line arguments
+ */
+export interface CliOptions {
+    /** Project name */
+    projectName?: string;
+    /** Template to use */
+    template?: TemplateType;
+    /** Skip prompts, use defaults */
+    yes?: boolean;
+    /** Show help */
+    help?: boolean;
+    /** Show version */
+    version?: boolean;
+    /** Skip dependency installation */
+    skipInstall?: boolean;
+    /** Skip git initialization */
+    skipGit?: boolean;
+    /** Use JavaScript instead of TypeScript */
+    javascript?: boolean;
+    /** Package manager to use */
+    packageManager?: 'npm' | 'yarn' | 'pnpm';
+}

--- a/packages/create/tsconfig.json
+++ b/packages/create/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/create/tsup.config.ts
+++ b/packages/create/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: {
+        index: 'src/index.ts',
+        cli: 'src/cli.ts',
+    },
+    format: ['cjs', 'esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    splitting: false,
+    banner: {
+        js: '#!/usr/bin/env node',
+    },
+    esbuildOptions(options) {
+        // Only add shebang banner to cli.js
+        if (options.entryPoints && Array.isArray(options.entryPoints)) {
+            const isCli = options.entryPoints.some(
+                (entry) => typeof entry === 'string' && entry.includes('cli')
+            );
+            if (!isCli) {
+                options.banner = {};
+            }
+        }
+    },
+});


### PR DESCRIPTION
Implements project scaffolding tools as described in issue #94.

Features:
- Interactive CLI with prompts for project configuration
- Support for multiple templates: vanilla, canvas2d, pixi, three, multiplayer, vite, webpack
- TypeScript and JavaScript language options
- Package manager selection (npm, yarn, pnpm)
- Automatic git initialization and dependency installation

Templates include:
- Complete ECS project structure with components, systems, and engine setup
- Proper package.json with dependencies and scripts
- README and .gitignore files
- Vite/Webpack configurations for browser-based templates
- Multiplayer template with WebSocket server/client

Usage: npm create @orion-ecs [project-name] [options]