### PR TITLE
docs: update project structure and package lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,19 +161,24 @@ Do NOT create changesets for:
 
 ```
 OrionECS/
-├── packages/           # Core packages (npm workspaces)
-│   ├── core/          # Main ECS engine (@orion-ecs/core)
-│   ├── graphics/      # Graphics utilities (@orion-ecs/graphics)
-│   ├── math/          # Math utilities (@orion-ecs/math)
-│   ├── plugin-api/    # Plugin API types (@orion-ecs/plugin-api)
-│   └── testing/       # Testing utilities (@orion-ecs/testing)
-├── plugins/           # Official plugins (physics, input, spatial, etc.)
-├── examples/          # Sample applications (games, integrations)
-├── benchmarks/        # Performance benchmarks
-└── docs/              # Tutorials, migrations, cookbook
+├── packages/              # Core packages (npm workspaces)
+│   ├── core/              # Main ECS engine (@orion-ecs/core)
+│   ├── graphics/          # Graphics utilities (@orion-ecs/graphics)
+│   ├── math/              # Math utilities (@orion-ecs/math)
+│   ├── plugin-api/        # Plugin API types (@orion-ecs/plugin-api)
+│   ├── testing/           # Testing utilities (@orion-ecs/testing)
+│   ├── eslint-plugin-ecs/ # ESLint rules for ECS patterns
+│   ├── vscode-extension/  # VS Code extension
+│   └── create/            # Project scaffolding CLI
+├── plugins/               # Official plugins (14 plugins)
+├── examples/              # Sample applications (games, integrations)
+├── tutorials/             # Runnable tutorial code
+├── benchmarks/            # Performance benchmarks
+├── docs/                  # Tutorials, migrations, cookbook
+└── scripts/               # Build and utility scripts
 ```
 
-**For detailed package breakdown, see [CONTRIBUTING.md](./CONTRIBUTING.md#project-structure).**
+**For detailed package and plugin breakdown, see [CONTRIBUTING.md](./CONTRIBUTING.md#project-structure).**
 
 ## Code Patterns
 
@@ -279,3 +284,5 @@ WebFetch('https://github.com/tyevco/OrionECS/issues/88', 'Extract issue details'
 | [PERFORMANCE.md](./PERFORMANCE.md) | Benchmarks, optimization tips |
 | [docs/COOKBOOK.md](./docs/COOKBOOK.md) | Recipes and patterns |
 | [docs/tutorials/](./docs/tutorials/) | Step-by-step tutorials |
+| [docs/PERFORMANCE-REGRESSION-TESTING.md](./docs/PERFORMANCE-REGRESSION-TESTING.md) | Performance regression testing system |
+| [docs/migrations/](./docs/migrations/) | Migration guides from other ECS frameworks |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,24 +91,40 @@ OrionECS uses a monorepo structure managed with npm workspaces and Turbo:
 
 ```
 OrionECS/
-├── core/               # Core ECS engine package
-│   ├── src/
-│   │   ├── engine.ts      # Engine facade and builder
-│   │   ├── core.ts        # Core ECS components
-│   │   ├── managers.ts    # Specialized managers
-│   │   ├── archetype.ts   # Archetype system
-│   │   └── definitions.ts # TypeScript interfaces
-│   └── package.json
-├── plugins/            # Official plugins
-│   ├── physics/
-│   ├── spatial-partition/
-│   ├── debug-visualizer/
-│   └── ...
-├── examples/           # Example applications
-│   ├── games/
-│   └── integrations/
-├── benchmarks/         # Performance benchmarks
-└── utils/              # Shared utilities
+├── packages/              # Core packages (npm workspaces)
+│   ├── core/              # Main ECS engine (@orion-ecs/core)
+│   ├── graphics/          # Graphics utilities (@orion-ecs/graphics)
+│   ├── math/              # Math utilities (@orion-ecs/math)
+│   ├── plugin-api/        # Plugin API types (@orion-ecs/plugin-api)
+│   ├── testing/           # Testing utilities (@orion-ecs/testing)
+│   ├── eslint-plugin-ecs/ # ESLint rules for ECS patterns
+│   ├── vscode-extension/  # VS Code extension
+│   └── create/            # Project scaffolding CLI
+├── plugins/               # Official plugins
+│   ├── budgets/           # Performance budgets & monitoring
+│   ├── canvas2d-renderer/ # Canvas2D rendering
+│   ├── debug-visualizer/  # Debug visualization
+│   ├── decision-tree/     # AI decision trees
+│   ├── entity-inspector/  # Entity inspection tools
+│   ├── input-manager/     # Input handling
+│   ├── interaction-system/# Interaction system
+│   ├── network/           # Networking support
+│   ├── physics/           # Physics simulation
+│   ├── profiling/         # Performance profiling
+│   ├── resource-manager/  # Resource management
+│   ├── spatial-partition/ # Spatial partitioning
+│   ├── state-machine/     # State machine support
+│   └── timeline/          # Timeline/animation system
+├── examples/              # Example applications
+│   ├── games/             # Game examples
+│   ├── integrations/      # Integration examples
+│   └── console-examples/  # Console-based examples
+├── tutorials/             # Runnable tutorial code
+├── benchmarks/            # Performance benchmarks
+├── docs/                  # Documentation
+│   ├── tutorials/         # Tutorial guides
+│   └── migrations/        # Migration guides
+└── scripts/               # Build and utility scripts
 ```
 
 ### Development Commands

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,15 +21,25 @@ The following packages can be published to npm:
   - `@orion-ecs/graphics` - Graphics primitives (Color, Mesh, Vertex)
   - `@orion-ecs/testing` - Testing utilities for ECS systems
   - `@orion-ecs/plugin-api` - Plugin API types for plugin authors
+- **Tooling Packages**:
+  - `@orion-ecs/eslint-plugin-ecs` - ESLint rules for ECS patterns
+  - `@orion-ecs/create` - Project scaffolding CLI
+  - `@orion-ecs/vscode-extension` - VS Code extension
 - **Plugin Packages**:
+  - `@orion-ecs/budgets` - Performance budgets and monitoring
   - `@orion-ecs/canvas2d-renderer` - Canvas2D rendering
+  - `@orion-ecs/debug-visualizer` - Debug visualization
+  - `@orion-ecs/decision-tree` - AI decision trees
+  - `@orion-ecs/entity-inspector` - Entity inspection tools
   - `@orion-ecs/input-manager` - Input handling
   - `@orion-ecs/interaction-system` - Interaction system
+  - `@orion-ecs/network` - Networking support
   - `@orion-ecs/physics` - Physics simulation
-  - `@orion-ecs/spatial-partition` - Spatial partitioning
-  - `@orion-ecs/debug-visualizer` - Debug visualization
   - `@orion-ecs/profiling` - Performance profiling
   - `@orion-ecs/resource-manager` - Resource management
+  - `@orion-ecs/spatial-partition` - Spatial partitioning
+  - `@orion-ecs/state-machine` - State machine support
+  - `@orion-ecs/timeline` - Timeline/animation system
 
 ## Authentication
 


### PR DESCRIPTION
- Fix CONTRIBUTING.md project structure to show accurate directory layout
  - Changed from incorrect root-level core/ to packages/core/
  - Added missing packages: create, eslint-plugin-ecs, vscode-extension
  - Added all 14 plugins with descriptions
  - Added tutorials/, scripts/, and docs/ subdirectories
  - Removed non-existent utils/ directory

- Update CLAUDE.md repository structure
  - Added missing packages to the structure
  - Added tutorials/ and scripts/ directories
  - Updated plugins count reference
  - Added performance regression testing and migrations to documentation table

- Update RELEASE.md package list
  - Added Tooling Packages section (eslint-plugin-ecs, create, vscode-extension)
  - Added missing plugins: budgets, decision-tree, entity-inspector, network, state-machine, timeline
  - Organized plugins alphabetically