### PR TITLE
feat(core): add tryGetComponent for null-safe component access

### DIFF
--- a/.changeset/add-try-get-component.md
+++ b/.changeset/add-try-get-component.md
@@ -1,0 +1,9 @@
+---
+"@orion-ecs/core": minor
+---
+
+Add tryGetComponent method for null-safe component access
+
+- Added `tryGetComponent` method to Entity that returns `T | null` instead of throwing
+- Refactored `getComponent` to use `tryGetComponent` internally for cleaner code
+- Enables safer component access patterns without needing hasComponent checks

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1118,35 +1118,31 @@ export class Entity implements EntityDef {
         return this._componentIndices.has(type);
     }
 
-    getComponent<T>(type: ComponentIdentifier<T>): T {
+    tryGetComponent<T>(type: ComponentIdentifier<T>): T | null {
         const index = this._componentIndices.get(type);
         if (index === undefined) {
-            throw new Error(
-                `[ECS] Component ${type.name} not found on entity ${this._name || this._numericId}`
-            );
+            return null;
         }
 
         const archetypeManager = this.componentManager.getArchetypeManager();
         if (archetypeManager) {
             // Archetype mode: get component from archetype
-            const component = archetypeManager.getComponent(this, type);
-            if (component === null) {
-                throw new Error(
-                    `[ECS] Component ${type.name} is null on entity ${this._name || this._numericId}`
-                );
-            }
-            return component as T;
+            return archetypeManager.getComponent(this, type);
         } else {
             // Legacy mode: get component from sparse array
             const componentArray = this.componentManager.getComponentArray(type);
-            const component = componentArray.get(index);
-            if (component === null) {
-                throw new Error(
-                    `[ECS] Component ${type.name} is null on entity ${this._name || this._numericId}`
-                );
-            }
-            return component as T;
+            return componentArray.get(index);
         }
+    }
+
+    getComponent<T>(type: ComponentIdentifier<T>): T {
+        const component = this.tryGetComponent(type);
+        if (component === null) {
+            throw new Error(
+                `[ECS] Component ${type.name} not found on entity ${this._name || this._numericId}`
+            );
+        }
+        return component;
     }
 
     addTag(tag: string): this {

--- a/packages/core/src/definitions.ts
+++ b/packages/core/src/definitions.ts
@@ -527,6 +527,8 @@ export interface EntityDef {
     hasComponent<T>(type: new (...args: any[]) => T): boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getComponent<T>(type: new (...args: any[]) => T): T;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tryGetComponent<T>(type: new (...args: any[]) => T): T | null;
     addTag(tag: string): this;
     removeTag(tag: string): this;
     hasTag(tag: string): boolean;

--- a/packages/core/src/engine.spec.ts
+++ b/packages/core/src/engine.spec.ts
@@ -463,6 +463,31 @@ describe('Engine v2 - Composition Architecture', () => {
             expect(pos.y).toBe(20);
         });
 
+        test('should tryGetComponent return component when present', () => {
+            const entity = engine.createEntity();
+            entity.addComponent(Position, 15, 25);
+
+            const pos = entity.tryGetComponent(Position);
+            expect(pos).not.toBeNull();
+            expect(pos?.x).toBe(15);
+            expect(pos?.y).toBe(25);
+        });
+
+        test('should tryGetComponent return null when component not present', () => {
+            const entity = engine.createEntity();
+
+            const pos = entity.tryGetComponent(Position);
+            expect(pos).toBeNull();
+        });
+
+        test('should getComponent throw when component not present', () => {
+            const entity = engine.createEntity('TestEntity');
+
+            expect(() => entity.getComponent(Position)).toThrow(
+                '[ECS] Component Position not found on entity TestEntity'
+            );
+        });
+
         test('should validate components', () => {
             engine.registerComponentValidator(Health, {
                 validate: (component: Health) => {


### PR DESCRIPTION
Add a tryGetComponent method to Entity that returns T | null instead of throwing an error when a component is not found. This provides a safer API for component access when the presence of a component is uncertain.

- Added tryGetComponent<T>(type): T | null to EntityDef interface
- Implemented tryGetComponent in Entity class
- Refactored getComponent to use tryGetComponent internally
- Added tests for both tryGetComponent and getComponent error cases