### PR TITLE
fix: improve ComponentIdentifier type safety with stricter utility types

### DIFF
--- a/.changeset/component-type-safety.md
+++ b/.changeset/component-type-safety.md
@@ -1,0 +1,12 @@
+---
+"@orion-ecs/core": minor
+---
+
+Add stricter component type utilities for improved type safety
+
+- Add `StrictComponentClass<T, Args>` type that captures both instance type and constructor arguments
+- Add `InferStrictComponentClass<C>` utility type to infer strict component types from constructors
+- Improve documentation for `ComponentIdentifier` explaining the type safety model and why `any[]` is used
+- Enhance `ComponentArgs<T>` documentation with usage examples
+
+These new types provide an opt-in stricter alternative for cases where compile-time validation of constructor arguments is needed at the definition site rather than just at call sites.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,8 @@ export type {
     EventCallback,
     EventTypes,
     ExtractPluginExtensions,
+    // Strict component typing utilities
+    InferStrictComponentClass,
     InstalledPlugin,
     Logger,
     LogLevel,
@@ -90,6 +92,7 @@ export type {
     RecoveryStrategy,
     SerializedEntity,
     SerializedWorld,
+    StrictComponentClass,
     SystemError,
     SystemErrorConfig,
     SystemHealth,


### PR DESCRIPTION
- Add StrictComponentClass<T, Args> type that captures both instance type and constructor arguments for compile-time validation at definition sites
- Add InferStrictComponentClass<C> utility to infer strict component types
- Improve ComponentIdentifier documentation explaining why any[] is required (TypeScript variance rules) and how type safety is achieved at call sites
- Enhance ComponentArgs<T> documentation with usage examples

The existing ComponentIdentifier type is unchanged for backward compatibility. The new types provide an opt-in stricter alternative for cases requiring compile-time constructor argument validation.