### PR TITLE
fix(core): improve EventCallback type safety with generic constraints

### DIFF
--- a/.changeset/fix-event-callback-types.md
+++ b/.changeset/fix-event-callback-types.md
@@ -1,0 +1,8 @@
+---
+"@orion-ecs/core": patch
+---
+
+Fix EventCallback type to preserve type information using generic constraints
+
+The EventCallback type now uses `TArgs extends unknown[]` instead of `any[]` for arguments,
+allowing callers to specify exact argument types while maintaining backward compatibility.

--- a/packages/core/src/definitions.ts
+++ b/packages/core/src/definitions.ts
@@ -71,8 +71,29 @@ export type ComponentTypes<T extends readonly ComponentIdentifier[]> = {
 /** @public */
 export type EventTypes<T = any> = string | symbol | keyof T;
 
-/** @public */
-export type EventCallback<T = void> = (...args: any[]) => T;
+/**
+ * Type-safe callback for event handlers.
+ *
+ * @typeParam TArgs - Tuple type representing the callback arguments (e.g., `[deltaTime: number]`)
+ * @typeParam TReturn - Return type of the callback
+ *
+ * @example
+ * ```typescript
+ * // Callback with no arguments
+ * type OnStart = EventCallback;
+ *
+ * // Callback with typed arguments
+ * type OnUpdate = EventCallback<[deltaTime: number]>;
+ *
+ * // Callback with multiple arguments and return value
+ * type OnValidate = EventCallback<[entity: Entity, component: Component], boolean>;
+ * ```
+ *
+ * @public
+ */
+export type EventCallback<TArgs extends unknown[] = unknown[], TReturn = void> = (
+    ...args: TArgs
+) => TReturn;
 
 /**
  * Optional lifecycle hooks that components can implement.


### PR DESCRIPTION
Replace `any[]` with generic `TArgs extends unknown[]` in EventCallback type to preserve type information for event callback arguments while maintaining backward compatibility with existing usages.