### PR TITLE
fix(core): improve type safety in plugin context methods

### DIFF
--- a/.changeset/fix-plugin-context-types.md
+++ b/.changeset/fix-plugin-context-types.md
@@ -1,0 +1,11 @@
+---
+"@orion-ecs/core": patch
+---
+
+Fix type safety in plugin context methods by returning proper types instead of `any`
+
+- `createSystem` now returns `System<ComponentTypes<All>>` instead of `any`
+- `createQuery` now returns `Query<ComponentTypes<All>>` instead of `any`
+- `getEngine` now returns `Engine` instead of `any`
+
+This improves TypeScript type inference for plugins using the plugin context API.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2398,13 +2398,13 @@ export class Engine {
                 name: string,
                 queryOptions: QueryOptions<All>,
                 options: SystemType<ComponentTypes<All>>,
-                isFixedUpdate: boolean = false
-            ): any => {
-                return this.createSystem(name, queryOptions, options, isFixedUpdate);
+                isFixedUpdate?: boolean
+            ): System<ComponentTypes<All>> => {
+                return this.createSystem(name, queryOptions, options, isFixedUpdate ?? false);
             },
             createQuery: <All extends readonly ComponentIdentifier[]>(
                 options: QueryOptions<All>
-            ): any => {
+            ): Query<ComponentTypes<All>> => {
                 return this.createQuery(options);
             },
             registerPrefab: (name: string, prefab: EntityPrefab): void => {
@@ -2460,7 +2460,7 @@ export class Engine {
                 (this as any)[extensionName] = api;
             },
             logger: this._logger,
-            getEngine: (): any => {
+            getEngine: (): Engine => {
                 return this;
             },
         };


### PR DESCRIPTION
Replace 'any' return types with proper generic types for plugin context methods. This enables better TypeScript type inference for plugins.

- createSystem returns System<ComponentTypes<All>>
- createQuery returns Query<ComponentTypes<All>>
- getEngine returns Engine