### PR TITLE
refactor(core): improve type safety in SystemManager arrays

### DIFF
--- a/.changeset/type-safety-system-manager.md
+++ b/.changeset/type-safety-system-manager.md
@@ -1,0 +1,5 @@
+---
+"@orion-ecs/core": patch
+---
+
+Improve type safety in SystemManager by replacing `System<any>[]` with `System<AnySystemTuple>[]` for heterogeneous system storage. This provides better type inference while maintaining flexibility for systems with different component requirements.

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1785,8 +1785,14 @@ export class Entity implements EntityDef {
 /**
  * SystemGroup for organizing systems into execution phases
  */
+/**
+ * Type constraint for heterogeneous system component tuples.
+ * Used for internal storage of systems with different component requirements.
+ */
+export type AnySystemTuple = readonly unknown[];
+
 export class SystemGroup {
-    systems: System<any>[] = [];
+    systems: System<AnySystemTuple>[] = [];
 
     constructor(
         public name: string,


### PR DESCRIPTION
Replace System<any>[] with System<AnySystemTuple>[] for heterogeneous system storage. This provides better type safety while maintaining flexibility for systems with different component requirements.

- Add AnySystemTuple type alias (readonly unknown[]) in core.ts
- Update SystemManager and SystemGroup to use the new type
- Add type assertions where needed due to TypeScript variance rules
- Update createSystem method generic constraint to use unknown
- Remove unnecessary eslint-disable comments for the improved types