### PR TITLE
fix: add generic type constraints to Archetype.forEach for type safety

### DIFF
--- a/.changeset/fix-archetype-foreach-types.md
+++ b/.changeset/fix-archetype-foreach-types.md
@@ -1,0 +1,5 @@
+---
+"@orion-ecs/core": patch
+---
+
+Improve type safety for Archetype.forEach callback by adding generic constraints to preserve component types

--- a/packages/core/src/archetype.spec.ts
+++ b/packages/core/src/archetype.spec.ts
@@ -194,7 +194,7 @@ describe('Archetype', () => {
 
             const results: Array<{ entity: Entity; position: Position; velocity: Velocity }> = [];
 
-            archetype.forEach((e, position, velocity) => {
+            archetype.forEach<[Position, Velocity]>((e, position, velocity) => {
                 results.push({ entity: e, position, velocity });
             });
 

--- a/packages/core/src/archetype.ts
+++ b/packages/core/src/archetype.ts
@@ -539,7 +539,9 @@ export class Archetype {
      * Thread Safety: During iteration, entity removals are automatically deferred
      * until iteration completes to prevent data corruption from concurrent modifications.
      */
-    forEach(callback: (entity: Entity, ...components: any[]) => void): void {
+    forEach<C extends readonly unknown[]>(
+        callback: (entity: Entity, ...components: C) => void
+    ): void {
         const componentArraysArray: any[][] = [];
 
         // Pre-fetch component arrays for better performance
@@ -562,7 +564,7 @@ export class Archetype {
                 // Skip entities that are pending removal
                 if (entity && !this._pendingRemovals.has(entity)) {
                     const components = componentArraysArray.map((arr) => arr[i]);
-                    callback(entity, ...components);
+                    callback(entity, ...(components as unknown as C));
                 }
             }
         } finally {


### PR DESCRIPTION
The forEach callback previously used `any[]` for component types, losing type information during iteration. This change adds a generic type parameter `C extends readonly unknown[]` that allows callers to specify expected component types for proper type inference.

Updated test to demonstrate the new type-safe API usage.