### PR TITLE
fix(core): improve type safety for ComponentManager heterogeneous sto…

### DIFF
--- a/.changeset/improve-component-manager-types.md
+++ b/.changeset/improve-component-manager-types.md
@@ -1,0 +1,5 @@
+---
+"@orion-ecs/core": patch
+---
+
+Improve type safety for ComponentManager heterogeneous storage by updating `getComponentArray<T>` to use `ComponentIdentifier<T>` parameter and adding a new `getPool<T>` method for type-safe pool access

--- a/packages/core/src/managers.ts
+++ b/packages/core/src/managers.ts
@@ -63,7 +63,18 @@ export class ComponentManager {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private singletonComponents: Map<ComponentIdentifier, any> = new Map();
 
-    getComponentArray<T>(type: ComponentIdentifier): ComponentArray<T> {
+    /**
+     * Get the component array for a specific component type.
+     * Creates a new array if one doesn't exist.
+     *
+     * Type safety is enforced via the generic parameter constraint - the type
+     * parameter T is bound to the ComponentIdentifier<T>, ensuring the returned
+     * ComponentArray<T> matches the requested component type.
+     *
+     * @param type - The component class/constructor
+     * @returns The ComponentArray for storing instances of this component type
+     */
+    getComponentArray<T>(type: ComponentIdentifier<T>): ComponentArray<T> {
         if (!this.componentArrays.has(type)) {
             this.componentArrays.set(type, new ComponentArray<T>());
         }
@@ -172,6 +183,20 @@ export class ComponentManager {
      */
     hasComponentPool<T extends object>(type: ComponentIdentifier<T>): boolean {
         return this.componentPools.has(type);
+    }
+
+    /**
+     * Get the pool for a specific component type.
+     *
+     * Type safety is enforced via the generic parameter constraint - the type
+     * parameter T is bound to the ComponentIdentifier<T>, ensuring the returned
+     * Pool<T> matches the requested component type.
+     *
+     * @param type - The component class/constructor
+     * @returns The Pool for this component type, or undefined if not registered
+     */
+    getPool<T extends object>(type: ComponentIdentifier<T>): Pool<T> | undefined {
+        return this.componentPools.get(type) as Pool<T> | undefined;
     }
 
     /**


### PR DESCRIPTION
…rage

- Update getComponentArray<T> to use ComponentIdentifier<T> parameter, ensuring the returned ComponentArray<T> matches the requested type
- Add getPool<T> method for type-safe pool access with proper generic constraints
- Add JSDoc documentation explaining type safety enforcement at API boundaries

The internal maps still use 'any' for heterogeneous storage (necessary due to TypeScript's type system limitations), but public API methods now properly enforce type safety via generic parameter constraints.