### PR TITLE
docs: add comprehensive JSDoc to manager classes

### DIFF
--- a/.changeset/add-jsdoc-managers.md
+++ b/.changeset/add-jsdoc-managers.md
@@ -1,0 +1,5 @@
+---
+"@orion-ecs/core": patch
+---
+
+Add comprehensive JSDoc documentation to all manager classes in managers.ts for improved IDE autocomplete and developer experience


### PR DESCRIPTION
Add detailed JSDoc documentation to all public methods in:
- ComponentManager: component arrays, validators, pools, singletons
- SystemManager: groups, system registration, execution
- QueryManager: query creation and entity matching
- PrefabManager: prefab registration, extension, variants
- SnapshotManager: world state snapshots
- MessageManager: pub/sub messaging

Includes @example code blocks, @param/@returns tags, and @throws documentation for better IDE autocomplete and DX.