### PR TITLE
refactor(core): extract helper methods from restoreSnapshot

### DIFF
--- a/.changeset/full-dodos-drive.md
+++ b/.changeset/full-dodos-drive.md
@@ -1,0 +1,5 @@
+---
+"@orion-ecs/core": patch
+---
+
+Internal refactoring of restoreSnapshot method for improved maintainability


### PR DESCRIPTION
Break down the 118-line restoreSnapshot method into focused helper methods:
- clearAllEntitiesForRestore: clears existing entities before restoration
- recreateEntitiesFromSnapshot: processes all root entities
- recreateEntityFromSnapshot: recursively recreates entity and children
- restoreEntityComponents: restores components to an entity
- restoreSnapshotSingletons: restores singleton components
- updateQueriesForRestoredEntities: updates queries with restored entities

This improves testability, maintainability, and readability.