### PR TITLE
fix(core): improve ComponentIdentifier type safety

### DIFF
--- a/.changeset/fix-component-type-safety.md
+++ b/.changeset/fix-component-type-safety.md
@@ -1,0 +1,5 @@
+---
+"@orion-ecs/core": patch
+---
+
+Improve type safety for ComponentIdentifier by adding optional Args type parameter and fixing method signatures that incorrectly used ConstructorParameters<ComponentIdentifier<T>>. This enables TypeScript to correctly infer constructor argument types at call sites while maintaining backward compatibility.

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -244,9 +244,9 @@ export class SpawnEntityBuilder {
     /**
      * Add a component to the entity.
      *
-     * @typeParam T - The component type
+     * @typeParam C - The component class type (inferred from the type parameter)
      * @param type - Component class/constructor
-     * @param args - Arguments to pass to the component constructor
+     * @param args - Arguments to pass to the component constructor (type-safe)
      * @returns This builder for method chaining
      *
      * @example
@@ -257,10 +257,7 @@ export class SpawnEntityBuilder {
      *   .with(Health, 100, 100);
      * ```
      */
-    with<T>(
-        type: ComponentIdentifier<T>,
-        ...args: ConstructorParameters<ComponentIdentifier<T>>
-    ): this {
+    with<C extends ComponentIdentifier>(type: C, ...args: ConstructorParameters<C>): this {
         this.spawnCommand.components.push({ type, args });
         return this;
     }
@@ -349,15 +346,12 @@ export class EntityCommandBuilder {
     /**
      * Queue adding a component to this entity.
      *
-     * @typeParam T - The component type
+     * @typeParam C - The component class type (inferred from the type parameter)
      * @param type - Component class/constructor
-     * @param args - Arguments to pass to the component constructor
+     * @param args - Arguments to pass to the component constructor (type-safe)
      * @returns This builder for method chaining
      */
-    addComponent<T>(
-        type: ComponentIdentifier<T>,
-        ...args: ConstructorParameters<ComponentIdentifier<T>>
-    ): this {
+    addComponent<C extends ComponentIdentifier>(type: C, ...args: ConstructorParameters<C>): this {
         this.commandBuffer['addCommand']({
             type: 'add_component',
             entityId: this.entityId,

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -959,10 +959,7 @@ export class Entity implements EntityDef {
         throw new Error('[ECS] Invalid entity type - expected Entity instance');
     }
 
-    addComponent<T>(
-        type: ComponentIdentifier<T>,
-        ...args: ConstructorParameters<typeof type>
-    ): this {
+    addComponent<C extends ComponentIdentifier>(type: C, ...args: ConstructorParameters<C>): this {
         if (!this._componentIndices.has(type)) {
             const validator = this.componentManager.getValidator(type);
 

--- a/plugins/canvas2d-renderer/src/Canvas2DRendererPlugin.spec.ts
+++ b/plugins/canvas2d-renderer/src/Canvas2DRendererPlugin.spec.ts
@@ -194,17 +194,17 @@ describe('Canvas2DRendererPlugin', () => {
             // Negative width should fail
             expect(() => {
                 entity.addComponent(Camera, -100, 600);
-            }).toThrow();
+            }).toThrow(/Camera dimensions must be positive/);
 
             // Negative height should fail
             expect(() => {
                 entity.addComponent(Camera, 800, -100);
-            }).toThrow();
+            }).toThrow(/Camera dimensions must be positive/);
 
             // Zero dimensions should fail
             expect(() => {
                 entity.addComponent(Camera, 0, 0);
-            }).toThrow();
+            }).toThrow(/Camera dimensions must be positive/);
         });
 
         test('should require Transform and ScreenElement', () => {
@@ -213,7 +213,7 @@ describe('Canvas2DRendererPlugin', () => {
             // Should fail without dependencies
             expect(() => {
                 entity.addComponent(Camera, 800, 600);
-            }).toThrow();
+            }).toThrow(/requires/);
         });
     });
 
@@ -247,8 +247,8 @@ describe('Canvas2DRendererPlugin', () => {
 
             // Should fail without mesh
             expect(() => {
-                entity.addComponent(Sprite, null);
-            }).toThrow();
+                entity.addComponent(Sprite, null as unknown as Mesh);
+            }).toThrow(/Sprite must have a mesh/);
         });
 
         test('should require Transform component', () => {
@@ -256,7 +256,7 @@ describe('Canvas2DRendererPlugin', () => {
 
             expect(() => {
                 entity.addComponent(Sprite, mockMesh);
-            }).toThrow();
+            }).toThrow(/requires/);
         });
     });
 
@@ -362,7 +362,9 @@ describe('Canvas2DRendererPlugin', () => {
             camera.addComponent(Transform, 0, 0);
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            expect(() => api.screenToWorld(100, 100, camera as any)).toThrow();
+            expect(() => api.screenToWorld(100, 100, camera as any)).toThrow(
+                /Component .* not found/
+            );
         });
 
         test('should return null if canvas not set', () => {
@@ -447,7 +449,7 @@ describe('Canvas2DRendererPlugin', () => {
                 { position: { x: -10, y: 10 } },
             ],
             color: { value: '#FF0000' },
-        };
+        } as unknown as Mesh;
 
         beforeEach(() => {
             api = (engine as EngineWithCanvas2D).canvas2d;
@@ -552,7 +554,7 @@ describe('Canvas2DRendererPlugin', () => {
                         { position: { x: 10, y: 10 } },
                     ],
                     color: { value: '#FF0000' },
-                });
+                } as unknown as Mesh);
             }
 
             expect(() => {
@@ -578,7 +580,7 @@ describe('Canvas2DRendererPlugin', () => {
             sprite.addComponent(Sprite, {
                 vertices: [{ position: { x: 0, y: 0 } }],
                 color: { value: '#FF0000' },
-            });
+            } as unknown as Mesh);
 
             expect(() => {
                 engine.start();
@@ -600,7 +602,7 @@ describe('Canvas2DRendererPlugin', () => {
             sprite.addComponent(Sprite, {
                 vertices: [],
                 color: { value: '#FF0000' },
-            });
+            } as unknown as Mesh);
 
             expect(() => {
                 engine.start();


### PR DESCRIPTION
- Add optional Args type parameter to ComponentIdentifier for opt-in
  stricter typing: ComponentIdentifier<T, Args>
- Fix method signatures that incorrectly used ConstructorParameters<ComponentIdentifier<T>> (always resolved to any[])
- Update SpawnEntityBuilder.with() and EntityCommandBuilder.addComponent() to use <C extends ComponentIdentifier> pattern for proper type inference
- Update EntityDef interface to use ComponentIdentifier consistently
- Update Entity.addComponent() to use the type-safe pattern

This change enables TypeScript to correctly infer constructor argument types at call sites while maintaining backward compatibility.