### PR TITLE
feat(ci): enable auto-merge for performance baseline PRs

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -365,6 +365,7 @@ jobs:
             --verbose
 
       - name: Create Pull Request for baseline update
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -379,3 +380,13 @@ jobs:
           delete-branch: true
           add-paths: |
             .performance/baseline.json
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
+            --auto \
+            --squash \
+            --delete-branch


### PR DESCRIPTION
Uses gh pr merge --auto to enable auto-merge after PR creation. The PR will automatically merge once all branch protection requirements are met.