### PR TITLE
feat(logging): add multiple log providers support

### DIFF
--- a/.changeset/log-providers-feature.md
+++ b/.changeset/log-providers-feature.md
@@ -1,0 +1,53 @@
+---
+"@orion-ecs/core": minor
+"@orion-ecs/plugin-api": minor
+---
+
+Add multiple log providers support for flexible log destinations
+
+This update introduces a provider-based logging architecture that allows developers to direct log output to multiple destinations simultaneously.
+
+**New Types in @orion-ecs/plugin-api:**
+- `LogProvider` interface for creating custom log destinations
+- `LogEntry` type containing structured log information (level, args, tag, timestamp)
+
+Plugin authors can now implement custom log providers with only the lightweight plugin-api dependency.
+
+**New Features in @orion-ecs/core:**
+- `ConsoleLogProvider` - built-in provider for console output (default)
+- `MemoryLogProvider` - built-in provider for capturing logs in memory (great for testing)
+- `EngineBuilder.withLogProvider()` - method for registering log providers during engine configuration
+
+**Usage Examples:**
+
+```typescript
+// Memory-only logging for tests (no console output)
+const memoryLog = new MemoryLogProvider();
+const engine = new EngineBuilder()
+  .withLogProvider(memoryLog)
+  .build();
+
+// Assert on captured logs
+expect(memoryLog.getByLevel('error')).toHaveLength(0);
+expect(memoryLog.search('entity created')).toHaveLength(1);
+
+// Multiple providers (console + memory)
+const engine = new EngineBuilder()
+  .withLogProvider(new ConsoleLogProvider())
+  .withLogProvider(memoryLog)
+  .build();
+
+// Custom provider for remote logging
+const remoteProvider: LogProvider = {
+  write(entry) {
+    if (entry.level === 'error') {
+      sendToErrorTracking(entry);
+    }
+  }
+};
+```
+
+**Backward Compatibility:**
+- Existing code continues to work without changes
+- If no providers are configured, `ConsoleLogProvider` is used by default
+- The `Logger` interface remains unchanged

--- a/packages/core/src/definitions.ts
+++ b/packages/core/src/definitions.ts
@@ -20,8 +20,10 @@ export type {
     EnginePlugin,
     ExtractPluginExtensions,
     InstalledPlugin,
+    LogEntry,
     Logger,
     LogLevel,
+    LogProvider,
     SystemMessage,
 } from '@orion-ecs/plugin-api';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,8 +80,10 @@ export type {
     // Strict component typing utilities
     InferStrictComponentClass,
     InstalledPlugin,
+    LogEntry,
     Logger,
     LogLevel,
+    LogProvider,
     MemoryStats,
     ParentChangedEvent,
     ParentChangedListener,
@@ -104,8 +106,10 @@ export type {
 } from './definitions';
 // Export the new Engine and Builder
 export { Engine, EngineBuilder } from './engine';
-// Export logger utilities
-export { EngineLogger, sanitizeLogString } from './logger';
+// Export logger utilities and providers
+// Note: LogEntry and LogProvider types are exported from definitions.ts (via plugin-api)
+export type { EngineLoggerOptions } from './logger';
+export { ConsoleLogProvider, EngineLogger, MemoryLogProvider, sanitizeLogString } from './logger';
 // Export managers
 export {
     ChangeTrackingManager,

--- a/packages/core/src/logger.spec.ts
+++ b/packages/core/src/logger.spec.ts
@@ -1,0 +1,431 @@
+import { EngineBuilder } from './engine';
+import {
+    ConsoleLogProvider,
+    EngineLogger,
+    type LogEntry,
+    type LogProvider,
+    MemoryLogProvider,
+    sanitizeLogString,
+} from './logger';
+
+describe('Log Providers', () => {
+    describe('sanitizeLogString', () => {
+        test('should remove ANSI escape sequences', () => {
+            const input = '\x1b[31mRed Text\x1b[0m';
+            expect(sanitizeLogString(input)).toBe('Red Text');
+        });
+
+        test('should remove control characters', () => {
+            const input = 'Hello\x00World\x1F!';
+            expect(sanitizeLogString(input)).toBe('HelloWorld!');
+        });
+
+        test('should handle non-string input', () => {
+            expect(sanitizeLogString(123 as unknown as string)).toBe('123');
+        });
+    });
+
+    describe('ConsoleLogProvider', () => {
+        let provider: ConsoleLogProvider;
+        let consoleSpy: {
+            log: jest.SpyInstance;
+            warn: jest.SpyInstance;
+            error: jest.SpyInstance;
+        };
+
+        beforeEach(() => {
+            provider = new ConsoleLogProvider();
+            consoleSpy = {
+                log: jest.spyOn(console, 'log').mockImplementation(),
+                warn: jest.spyOn(console, 'warn').mockImplementation(),
+                error: jest.spyOn(console, 'error').mockImplementation(),
+            };
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should write debug messages to console.log', () => {
+            const entry: LogEntry = {
+                level: 'debug',
+                args: ['Debug message'],
+                tag: 'TestTag',
+                timestamp: Date.now(),
+            };
+
+            provider.write(entry);
+
+            expect(consoleSpy.log).toHaveBeenCalledWith('[TestTag]', 'Debug message');
+        });
+
+        test('should write info messages to console.log', () => {
+            const entry: LogEntry = {
+                level: 'info',
+                args: ['Info message'],
+                timestamp: Date.now(),
+            };
+
+            provider.write(entry);
+
+            expect(consoleSpy.log).toHaveBeenCalledWith('[ECS]', 'Info message');
+        });
+
+        test('should write warn messages to console.warn', () => {
+            const entry: LogEntry = {
+                level: 'warn',
+                args: ['Warning message'],
+                timestamp: Date.now(),
+            };
+
+            provider.write(entry);
+
+            expect(consoleSpy.warn).toHaveBeenCalledWith('[ECS]', 'Warning message');
+        });
+
+        test('should write error messages to console.error', () => {
+            const entry: LogEntry = {
+                level: 'error',
+                args: ['Error message'],
+                timestamp: Date.now(),
+            };
+
+            provider.write(entry);
+
+            expect(consoleSpy.error).toHaveBeenCalledWith('[ECS]', 'Error message');
+        });
+    });
+
+    describe('MemoryLogProvider', () => {
+        let provider: MemoryLogProvider;
+
+        beforeEach(() => {
+            provider = new MemoryLogProvider();
+        });
+
+        test('should store log entries', () => {
+            const entry: LogEntry = {
+                level: 'info',
+                args: ['Test message'],
+                tag: 'TestTag',
+                timestamp: Date.now(),
+            };
+
+            provider.write(entry);
+
+            expect(provider.entries).toHaveLength(1);
+            expect(provider.entries[0]).toEqual(entry);
+        });
+
+        test('should respect maxEntries limit', () => {
+            const limitedProvider = new MemoryLogProvider({ maxEntries: 3 });
+
+            for (let i = 0; i < 5; i++) {
+                limitedProvider.write({
+                    level: 'info',
+                    args: [`Message ${i}`],
+                    timestamp: Date.now(),
+                });
+            }
+
+            expect(limitedProvider.entries).toHaveLength(3);
+            expect(limitedProvider.entries[0]!.args[0]).toBe('Message 2');
+            expect(limitedProvider.entries[2]!.args[0]).toBe('Message 4');
+        });
+
+        test('should clear entries', () => {
+            provider.write({
+                level: 'info',
+                args: ['Test'],
+                timestamp: Date.now(),
+            });
+
+            provider.clear();
+
+            expect(provider.entries).toHaveLength(0);
+        });
+
+        test('should filter entries by level', () => {
+            provider.write({ level: 'info', args: ['Info 1'], timestamp: Date.now() });
+            provider.write({ level: 'error', args: ['Error 1'], timestamp: Date.now() });
+            provider.write({ level: 'info', args: ['Info 2'], timestamp: Date.now() });
+
+            const infoEntries = provider.getByLevel('info');
+            const errorEntries = provider.getByLevel('error');
+
+            expect(infoEntries).toHaveLength(2);
+            expect(errorEntries).toHaveLength(1);
+        });
+
+        test('should filter entries by tag', () => {
+            provider.write({ level: 'info', args: ['A'], tag: 'TagA', timestamp: Date.now() });
+            provider.write({ level: 'info', args: ['B'], tag: 'TagB', timestamp: Date.now() });
+            provider.write({ level: 'info', args: ['A2'], tag: 'TagA', timestamp: Date.now() });
+
+            const tagAEntries = provider.getByTag('TagA');
+
+            expect(tagAEntries).toHaveLength(2);
+        });
+
+        test('should search entries by text', () => {
+            provider.write({ level: 'info', args: ['Hello World'], timestamp: Date.now() });
+            provider.write({ level: 'info', args: ['Goodbye'], timestamp: Date.now() });
+            provider.write({ level: 'info', args: ['Hello Again'], timestamp: Date.now() });
+
+            const results = provider.search('hello');
+
+            expect(results).toHaveLength(2);
+        });
+    });
+
+    describe('EngineLogger', () => {
+        test('should use ConsoleLogProvider by default', () => {
+            const logger = new EngineLogger();
+            const providers = logger.getProviders();
+
+            expect(providers).toHaveLength(1);
+            expect(providers[0]).toBeInstanceOf(ConsoleLogProvider);
+        });
+
+        test('should dispatch to multiple providers', () => {
+            const memory1 = new MemoryLogProvider();
+            const memory2 = new MemoryLogProvider();
+
+            const logger = new EngineLogger({
+                debugEnabled: true,
+                providers: [memory1, memory2],
+            });
+
+            logger.info('Test message');
+
+            expect(memory1.entries).toHaveLength(1);
+            expect(memory2.entries).toHaveLength(1);
+        });
+
+        test('should not log debug when disabled', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({
+                debugEnabled: false,
+                providers: [memory],
+            });
+
+            logger.debug('Debug message');
+
+            expect(memory.entries).toHaveLength(0);
+        });
+
+        test('should log debug when enabled', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({
+                debugEnabled: true,
+                providers: [memory],
+            });
+
+            logger.debug('Debug message');
+
+            expect(memory.entries).toHaveLength(1);
+            expect(memory.entries[0]!.level).toBe('debug');
+        });
+
+        test('should respect minLevel setting', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({
+                minLevel: 'warn',
+                providers: [memory],
+            });
+
+            logger.info('Info');
+            logger.warn('Warning');
+            logger.error('Error');
+
+            expect(memory.entries).toHaveLength(2);
+            expect(memory.entries.map((e) => e.level)).toEqual(['warn', 'error']);
+        });
+
+        test('should sanitize string arguments', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({ providers: [memory] });
+
+            logger.info('Test \x1b[31mred\x1b[0m text');
+
+            expect(memory.entries[0]!.args[0]).toBe('Test red text');
+        });
+
+        test('should sanitize Error messages', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({ providers: [memory] });
+
+            logger.error(new Error('Error with \x00control chars'));
+
+            expect(memory.entries[0]!.args[0]).toBe('Error with control chars');
+        });
+
+        test('should create tagged logger that shares providers', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({ providers: [memory] });
+            const taggedLogger = logger.withTag('MySystem');
+
+            taggedLogger.info('Tagged message');
+
+            expect(memory.entries).toHaveLength(1);
+            expect(memory.entries[0]!.tag).toBe('MySystem');
+        });
+
+        test('should chain tags', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({ providers: [memory] });
+            const level1 = logger.withTag('Plugin');
+            const level2 = level1.withTag('SubModule');
+
+            (level2 as EngineLogger).info('Nested message');
+
+            expect(memory.entries[0]!.tag).toBe('Plugin:SubModule');
+        });
+
+        test('should add and remove providers', () => {
+            const logger = new EngineLogger({ providers: [] });
+            const memory = new MemoryLogProvider();
+
+            logger.addProvider(memory);
+            expect(logger.getProviders()).toHaveLength(1);
+
+            logger.removeProvider(memory);
+            expect(logger.getProviders()).toHaveLength(0);
+        });
+
+        test('should not add duplicate providers', () => {
+            const logger = new EngineLogger({ providers: [] });
+            const memory = new MemoryLogProvider();
+
+            logger.addProvider(memory);
+            logger.addProvider(memory);
+
+            expect(logger.getProviders()).toHaveLength(1);
+        });
+
+        test('should isolate provider errors', () => {
+            const failingProvider: LogProvider = {
+                write: () => {
+                    throw new Error('Provider failed');
+                },
+            };
+            const memory = new MemoryLogProvider();
+
+            const logger = new EngineLogger({
+                providers: [failingProvider, memory],
+            });
+
+            // Should not throw
+            expect(() => logger.info('Test')).not.toThrow();
+
+            // Memory provider should still receive the message
+            expect(memory.entries).toHaveLength(1);
+        });
+
+        test('should include timestamp in log entries', () => {
+            const memory = new MemoryLogProvider();
+            const logger = new EngineLogger({ providers: [memory] });
+
+            const before = Date.now();
+            logger.info('Test');
+            const after = Date.now();
+
+            expect(memory.entries[0]!.timestamp).toBeGreaterThanOrEqual(before);
+            expect(memory.entries[0]!.timestamp).toBeLessThanOrEqual(after);
+        });
+
+        test('should flush providers', async () => {
+            let flushed = false;
+            const flushableProvider: LogProvider = {
+                write: () => {},
+                flush: () => {
+                    flushed = true;
+                },
+            };
+
+            const logger = new EngineLogger({ providers: [flushableProvider] });
+            await logger.flush();
+
+            expect(flushed).toBe(true);
+        });
+
+        test('should dispose providers', async () => {
+            let disposed = false;
+            const disposableProvider: LogProvider = {
+                write: () => {},
+                dispose: () => {
+                    disposed = true;
+                },
+            };
+
+            const logger = new EngineLogger({ providers: [disposableProvider] });
+            await logger.dispose();
+
+            expect(disposed).toBe(true);
+            expect(logger.getProviders()).toHaveLength(0);
+        });
+    });
+
+    describe('EngineBuilder.withLogProvider', () => {
+        test('should configure engine with custom log provider', () => {
+            const memory = new MemoryLogProvider();
+
+            const engine = new EngineBuilder().withDebugMode(true).withLogProvider(memory).build();
+
+            // The engine logs a debug message about archetypes when built
+            // Filter for archetype-related messages
+            const archetypeLogs = memory.search('archetype');
+            expect(archetypeLogs.length).toBeGreaterThan(0);
+
+            engine.destroy();
+        });
+
+        test('should support multiple providers via chaining', () => {
+            const memory1 = new MemoryLogProvider();
+            const memory2 = new MemoryLogProvider();
+
+            const engine = new EngineBuilder()
+                .withDebugMode(true)
+                .withLogProvider(memory1)
+                .withLogProvider(memory2)
+                .build();
+
+            // Both providers should receive the archetype log
+            expect(memory1.entries.length).toBeGreaterThan(0);
+            expect(memory2.entries.length).toBeGreaterThan(0);
+
+            engine.destroy();
+        });
+
+        test('should not include console output when only memory provider is used', () => {
+            const memory = new MemoryLogProvider();
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+            const engine = new EngineBuilder().withDebugMode(true).withLogProvider(memory).build();
+
+            // Console should not receive logs (memory is the only provider)
+            // Note: There might be some console output from other sources,
+            // but engine debug logs should go only to memory
+            const memoryHasLogs = memory.entries.length > 0;
+            expect(memoryHasLogs).toBe(true);
+
+            engine.destroy();
+            consoleSpy.mockRestore();
+        });
+
+        test('should use default ConsoleLogProvider when no providers specified', () => {
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+            const engine = new EngineBuilder().withDebugMode(true).build();
+
+            // Console should receive the archetype debug message
+            const archetypeLogCalled = consoleSpy.mock.calls.some((call) =>
+                call.some((arg) => String(arg).toLowerCase().includes('archetype'))
+            );
+            expect(archetypeLogCalled).toBe(true);
+
+            engine.destroy();
+            consoleSpy.mockRestore();
+        });
+    });
+});

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -2,13 +2,21 @@
  * Logger Implementation for OrionECS
  *
  * Provides secure, structured logging with automatic sanitization
- * to prevent log injection attacks.
+ * to prevent log injection attacks. Supports multiple log providers
+ * for flexible output destinations.
  *
  * @packageDocumentation
  * @module Logger
  */
 
-import type { Logger, LogLevel } from './definitions';
+import type { LogEntry, Logger, LogLevel, LogProvider } from './definitions';
+
+// Re-export types from plugin-api for convenience
+export type { LogEntry, LogProvider } from './definitions';
+
+// =============================================================================
+// Sanitization Utilities
+// =============================================================================
 
 /**
  * Sanitize a string to prevent log injection attacks.
@@ -63,6 +71,150 @@ function sanitizeArgs(args: unknown[]): unknown[] {
     });
 }
 
+// =============================================================================
+// Built-in Log Providers
+// =============================================================================
+
+/**
+ * Console log provider that outputs to the browser/Node.js console.
+ *
+ * This is the default provider used when no providers are explicitly configured.
+ *
+ * @example
+ * ```typescript
+ * const engine = new EngineBuilder()
+ *   .withLogProvider(new ConsoleLogProvider())
+ *   .build();
+ * ```
+ *
+ * @public
+ */
+export class ConsoleLogProvider implements LogProvider {
+    /**
+     * Write a log entry to the console.
+     *
+     * Uses console.log for debug/info, console.warn for warn, and console.error for error.
+     */
+    write(entry: LogEntry): void {
+        const prefix = entry.tag ? `[${entry.tag}]` : '[ECS]';
+
+        switch (entry.level) {
+            case 'debug':
+            case 'info':
+                console.log(prefix, ...entry.args);
+                break;
+            case 'warn':
+                console.warn(prefix, ...entry.args);
+                break;
+            case 'error':
+                console.error(prefix, ...entry.args);
+                break;
+        }
+    }
+}
+
+/**
+ * Memory log provider that stores log entries in an array.
+ *
+ * Useful for testing, debugging, and capturing logs for later analysis.
+ * Supports optional maximum entry limits to prevent unbounded memory growth.
+ *
+ * @example Testing log output
+ * ```typescript
+ * const memoryProvider = new MemoryLogProvider();
+ * const engine = new EngineBuilder()
+ *   .withLogProvider(memoryProvider)
+ *   .build();
+ *
+ * // ... run game logic ...
+ *
+ * expect(memoryProvider.entries).toContainEqual(
+ *   expect.objectContaining({ level: 'info', tag: 'MySystem' })
+ * );
+ * ```
+ *
+ * @example In-game debug console
+ * ```typescript
+ * const memoryProvider = new MemoryLogProvider({ maxEntries: 100 });
+ * // Display memoryProvider.entries in your debug UI
+ * ```
+ *
+ * @public
+ */
+export class MemoryLogProvider implements LogProvider {
+    /** Stored log entries */
+    readonly entries: LogEntry[] = [];
+
+    /** Maximum number of entries to store (0 = unlimited) */
+    private readonly maxEntries: number;
+
+    /**
+     * Create a new memory log provider.
+     *
+     * @param options - Configuration options
+     * @param options.maxEntries - Maximum entries to store (default: 0 = unlimited)
+     */
+    constructor(options: { maxEntries?: number } = {}) {
+        this.maxEntries = options.maxEntries ?? 0;
+    }
+
+    /**
+     * Write a log entry to memory.
+     */
+    write(entry: LogEntry): void {
+        this.entries.push(entry);
+
+        // Trim if we exceed maxEntries
+        if (this.maxEntries > 0 && this.entries.length > this.maxEntries) {
+            this.entries.shift();
+        }
+    }
+
+    /**
+     * Clear all stored log entries.
+     */
+    clear(): void {
+        this.entries.length = 0;
+    }
+
+    /**
+     * Get entries filtered by level.
+     *
+     * @param level - The log level to filter by
+     * @returns Entries matching the specified level
+     */
+    getByLevel(level: LogLevel): LogEntry[] {
+        return this.entries.filter((entry) => entry.level === level);
+    }
+
+    /**
+     * Get entries filtered by tag.
+     *
+     * @param tag - The tag to filter by
+     * @returns Entries matching the specified tag
+     */
+    getByTag(tag: string): LogEntry[] {
+        return this.entries.filter((entry) => entry.tag === tag);
+    }
+
+    /**
+     * Search entries by text content.
+     *
+     * @param text - Text to search for in log arguments
+     * @returns Entries containing the specified text
+     */
+    search(text: string): LogEntry[] {
+        const lowerText = text.toLowerCase();
+        return this.entries.filter((entry) =>
+            entry.args.some((arg) => String(arg).toLowerCase().includes(lowerText))
+        );
+    }
+}
+
+// =============================================================================
+// Logger Configuration
+// =============================================================================
+
 /**
  * Configuration options for the EngineLogger.
  */
@@ -71,6 +223,8 @@ export interface EngineLoggerOptions {
     debugEnabled?: boolean;
     /** Minimum log level to output */
     minLevel?: LogLevel;
+    /** Log providers to use (defaults to ConsoleLogProvider if empty) */
+    providers?: LogProvider[];
 }
 
 /**
@@ -83,28 +237,51 @@ const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
     error: 3,
 };
 
+// =============================================================================
+// Engine Logger
+// =============================================================================
+
 /**
- * Engine logger implementation with automatic sanitization.
+ * Engine logger implementation with automatic sanitization and multiple providers.
  *
  * This class implements the Logger interface and provides secure logging
- * with ANSI escape sequence and control character filtering.
+ * with ANSI escape sequence and control character filtering. Log messages
+ * are dispatched to all registered providers.
+ *
+ * @example Basic usage
+ * ```typescript
+ * const logger = new EngineLogger({ debugEnabled: true });
+ * logger.info('Engine started');
+ * logger.debug('Processing entity:', entityId);
+ * ```
+ *
+ * @example Multiple providers
+ * ```typescript
+ * const memoryProvider = new MemoryLogProvider();
+ * const logger = new EngineLogger({
+ *   providers: [new ConsoleLogProvider(), memoryProvider]
+ * });
+ * ```
+ *
+ * @public
  */
 export class EngineLogger implements Logger {
     private tag: string;
     private debugEnabled: boolean;
     private minLevel: LogLevel;
+    private providers: LogProvider[];
 
     constructor(options: EngineLoggerOptions = {}, tag: string = '') {
         this.tag = tag;
         this.debugEnabled = options.debugEnabled ?? false;
         this.minLevel = options.minLevel ?? 'info';
-    }
-
-    /**
-     * Format the log prefix with tag if present.
-     */
-    private formatPrefix(): string {
-        return this.tag ? `[${this.tag}]` : '[ECS]';
+        // Default to ConsoleLogProvider only if providers option is not explicitly set
+        // If providers is explicitly set (even as empty array), respect that choice
+        if (options.providers !== undefined) {
+            this.providers = [...options.providers];
+        } else {
+            this.providers = [new ConsoleLogProvider()];
+        }
     }
 
     /**
@@ -116,48 +293,77 @@ export class EngineLogger implements Logger {
             return this.debugEnabled;
         }
         // Other levels are checked against minLevel
-        return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[this.minLevel];
+        // LogLevel is a union type so the keys are guaranteed to exist
+        const levelPriority = LOG_LEVEL_PRIORITY[level] as number;
+        const minLevelPriority = LOG_LEVEL_PRIORITY[this.minLevel] as number;
+        return levelPriority >= minLevelPriority;
+    }
+
+    /**
+     * Dispatch a log entry to all providers.
+     */
+    private dispatch(level: LogLevel, args: unknown[]): void {
+        if (!this.isEnabled(level)) return;
+
+        const entry: LogEntry = {
+            level,
+            args: sanitizeArgs(args),
+            tag: this.tag || undefined,
+            timestamp: Date.now(),
+        };
+
+        // Dispatch to all providers with error isolation
+        for (const provider of this.providers) {
+            try {
+                provider.write(entry);
+            } catch {
+                // Silently ignore provider errors to prevent cascading failures
+                // A failing provider shouldn't crash the engine or prevent other providers
+            }
+        }
     }
 
     /**
      * Log a debug message (only when debug mode is enabled).
      */
     debug(...args: unknown[]): void {
-        if (!this.isEnabled('debug')) return;
-        console.log(this.formatPrefix(), ...sanitizeArgs(args));
+        this.dispatch('debug', args);
     }
 
     /**
      * Log an informational message.
      */
     info(...args: unknown[]): void {
-        if (!this.isEnabled('info')) return;
-        console.log(this.formatPrefix(), ...sanitizeArgs(args));
+        this.dispatch('info', args);
     }
 
     /**
      * Log a warning message.
      */
     warn(...args: unknown[]): void {
-        if (!this.isEnabled('warn')) return;
-        console.warn(this.formatPrefix(), ...sanitizeArgs(args));
+        this.dispatch('warn', args);
     }
 
     /**
      * Log an error message.
      */
     error(...args: unknown[]): void {
-        if (!this.isEnabled('error')) return;
-        console.error(this.formatPrefix(), ...sanitizeArgs(args));
+        this.dispatch('error', args);
     }
 
     /**
      * Create a new logger instance with a tag prefix.
+     *
+     * The new logger shares the same providers as the parent logger.
      */
     withTag(tag: string): Logger {
         const newTag = this.tag ? `${this.tag}:${tag}` : tag;
         const logger = new EngineLogger(
-            { debugEnabled: this.debugEnabled, minLevel: this.minLevel },
+            {
+                debugEnabled: this.debugEnabled,
+                minLevel: this.minLevel,
+                providers: this.providers,
+            },
             newTag
         );
         return logger;
@@ -175,5 +381,99 @@ export class EngineLogger implements Logger {
      */
     setMinLevel(level: LogLevel): void {
         this.minLevel = level;
+    }
+
+    // =========================================================================
+    // Provider Management
+    // =========================================================================
+
+    /**
+     * Add a log provider.
+     *
+     * @param provider - The provider to add
+     */
+    addProvider(provider: LogProvider): void {
+        if (!this.providers.includes(provider)) {
+            this.providers.push(provider);
+        }
+    }
+
+    /**
+     * Remove a log provider.
+     *
+     * @param provider - The provider to remove
+     * @returns true if the provider was found and removed
+     */
+    removeProvider(provider: LogProvider): boolean {
+        const index = this.providers.indexOf(provider);
+        if (index !== -1) {
+            this.providers.splice(index, 1);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get all registered providers.
+     *
+     * @returns Array of registered providers
+     */
+    getProviders(): ReadonlyArray<LogProvider> {
+        return this.providers;
+    }
+
+    /**
+     * Clear all providers and optionally add new ones.
+     *
+     * @param newProviders - Optional new providers to set
+     */
+    setProviders(newProviders: LogProvider[]): void {
+        this.providers = [...newProviders];
+    }
+
+    /**
+     * Flush all providers that support flushing.
+     *
+     * Useful for ensuring all logs are written before shutdown.
+     */
+    async flush(): Promise<void> {
+        const flushPromises: Promise<void>[] = [];
+
+        for (const provider of this.providers) {
+            if (provider.flush) {
+                const result = provider.flush();
+                if (result instanceof Promise) {
+                    flushPromises.push(result);
+                }
+            }
+        }
+
+        if (flushPromises.length > 0) {
+            await Promise.all(flushPromises);
+        }
+    }
+
+    /**
+     * Dispose all providers and clear the provider list.
+     *
+     * Called during engine cleanup.
+     */
+    async dispose(): Promise<void> {
+        const disposePromises: Promise<void>[] = [];
+
+        for (const provider of this.providers) {
+            if (provider.dispose) {
+                const result = provider.dispose();
+                if (result instanceof Promise) {
+                    disposePromises.push(result);
+                }
+            }
+        }
+
+        if (disposePromises.length > 0) {
+            await Promise.all(disposePromises);
+        }
+
+        this.providers = [];
     }
 }


### PR DESCRIPTION
Introduce a provider-based logging architecture that enables directing log output to multiple destinations simultaneously.

New types in @orion-ecs/plugin-api:
- LogProvider interface for custom log destinations
- LogEntry type with structured log information

Plugin authors can now implement custom log providers with only the lightweight plugin-api dependency.

New features in @orion-ecs/core:
- ConsoleLogProvider - built-in provider for console output (default)
- MemoryLogProvider - built-in provider for capturing logs in memory
- EngineBuilder.withLogProvider() - method for registering providers

This allows developers to:
- Capture logs for testing without console.spy()
- Log to files, remote services, or in-game UI
- Stack multiple providers for debugging
- Implement custom logging destinations

Backward compatible - existing code works without changes.

Closes #345