### PR TITLE
fix(ci): use rebase instead of squash for performance baseline PRs

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -388,5 +388,5 @@ jobs:
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
             --auto \
-            --squash \
+            --rebase \
             --delete-branch


### PR DESCRIPTION
Squash merging is not allowed on this repository, causing the auto-merge
to fail with "Merge method squash merging is not allowed". Changed to
use rebase merge instead.