### PR TITLE
fix(workspace): add entity-inspector plugin to workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "plugins/canvas2d-renderer",
         "plugins/debug-visualizer",
         "plugins/decision-tree",
+        "plugins/entity-inspector",
         "plugins/input-manager",
         "plugins/interaction-system",
         "plugins/physics",
@@ -5223,6 +5224,10 @@
     },
     "node_modules/@orion-ecs/decision-tree": {
       "resolved": "plugins/decision-tree",
+      "link": true
+    },
+    "node_modules/@orion-ecs/entity-inspector": {
+      "resolved": "plugins/entity-inspector",
       "link": true
     },
     "node_modules/@orion-ecs/eslint-plugin-ecs": {
@@ -15740,6 +15745,26 @@
       "peerDependencies": {
         "@orion-ecs/core": "*",
         "@orion-ecs/plugin-api": "*"
+      }
+    },
+    "plugins/entity-inspector": {
+      "name": "@orion-ecs/entity-inspector",
+      "version": "0.4.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@orion-ecs/core": "*",
+        "@orion-ecs/plugin-api": "*",
+        "@orion-ecs/testing": "*",
+        "@types/jest": "^30.0.0",
+        "@types/ws": "^8.0.0",
+        "jest": "^30.0.0",
+        "ts-jest": "^29.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "ws": "^8.0.0"
+      },
+      "peerDependencies": {
+        "@orion-ecs/core": "*"
       }
     },
     "plugins/input-manager": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "plugins/canvas2d-renderer",
     "plugins/debug-visualizer",
     "plugins/decision-tree",
+    "plugins/entity-inspector",
     "plugins/input-manager",
     "plugins/interaction-system",
     "plugins/physics",


### PR DESCRIPTION
The entity-inspector plugin directory exists but was missing from
the workspaces array in package.json, causing changeset validation
to fail with "package not in workspace" error.