### PR TITLE
fix(create): remove biome.json with relative extends path

### DIFF
--- a/packages/create/biome.json
+++ b/packages/create/biome.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
-  "extends": ["../../biome.json"],
-  "vcs": {
-    "enabled": false
-  }
-}


### PR DESCRIPTION
The packages/create/biome.json file extended ../../biome.json which caused lint-staged to fail during commit hooks when running from a stash context. Since it only disabled VCS (not critical), removing it lets the root biome.json config apply directly.