### PR TITLE
fix(ci): skip changeset check for release workflow pushes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check for changeset requirement before pushing
 # This helps catch missing changesets before CI runs
 
@@ -5,10 +7,23 @@
 remote="$1"
 url="$2"
 
+# Skip check in CI environment (changeset action handles its own validation)
+if [ -n "$CI" ]; then
+    exit 0
+fi
+
 # Only check when pushing to origin (not forks or other remotes)
 if [[ "$url" != *"tyevco/OrionECS"* ]] && [[ "$remote" != "origin" ]]; then
     exit 0
 fi
+
+# Skip check for changeset-release branches (these are created by the release workflow
+# after changesets have already been consumed and versions bumped)
+while read local_ref local_sha remote_ref remote_sha; do
+    if [[ "$remote_ref" == *"changeset-release/"* ]]; then
+        exit 0
+    fi
+done
 
 # Determine the base branch to compare against
 # Default to origin/main, but could be customized


### PR DESCRIPTION
The pre-push hook was blocking the changeset action from pushing to the changeset-release/main branch because all changesets had already been consumed by the version command.

Changes:
- Add bash shebang (fixes [[: not found error in CI)
- Skip check when CI environment variable is set
- Skip check when pushing to changeset-release/* branches