### PR TITLE
ci: cancel running workflows on PR merge

### DIFF
--- a/.github/workflows/cancel-on-merge.yml
+++ b/.github/workflows/cancel-on-merge.yml
@@ -1,0 +1,21 @@
+name: Cancel Workflows on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel-workflows:
+    name: Cancel Running Workflows
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    permissions:
+      actions: write
+
+    steps:
+      - name: Cancel in-progress workflow runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          workflow_id: ci.yml,pr-checks.yml,pr-validation.yml,benchmark.yml,performance.yml,codeql.yml
+          ignore_sha: true
+          all_but_latest: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Determine what files changed to run appropriate checks
   changes:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   size-label:
     name: Size Label

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Determine what files changed to run appropriate validations
   changes:


### PR DESCRIPTION
Add concurrency groups to PR-related workflows to automatically cancel
in-progress runs when new commits are pushed. Also add a dedicated
workflow to cancel any remaining runs when a PR is merged.

- Add concurrency groups to ci.yml, pr-checks.yml, pr-validation.yml
- Create cancel-on-merge.yml to explicitly cancel workflows on merge