### PR TITLE
style(create): fix biome formatting issues

### DIFF
--- a/packages/create/src/generator.ts
+++ b/packages/create/src/generator.ts
@@ -79,7 +79,9 @@ export async function createProject(config: ProjectConfig): Promise<boolean> {
             } catch {
                 console.log(pc.yellow('  ⚠') + pc.dim(' Failed to install dependencies'));
                 console.log(
-                    pc.dim(`    Run "${config.packageManager} install" manually to install dependencies`)
+                    pc.dim(
+                        `    Run "${config.packageManager} install" manually to install dependencies`
+                    )
                 );
             }
         }

--- a/packages/create/src/templates.ts
+++ b/packages/create/src/templates.ts
@@ -113,7 +113,11 @@ export const templates: Record<TemplateType, TemplateInfo> = {
 /**
  * Get all template options for prompts
  */
-export function getTemplateChoices(): Array<{ title: string; value: TemplateType; description: string }> {
+export function getTemplateChoices(): Array<{
+    title: string;
+    value: TemplateType;
+    description: string;
+}> {
     return Object.values(templates).map((template) => ({
         title: template.name,
         value: template.id,


### PR DESCRIPTION
Apply formatting fixes to generator.ts and templates.ts after removing the package-level biome.json override.